### PR TITLE
QuickStart corrections

### DIFF
--- a/en/quickstart.texy
+++ b/en/quickstart.texy
@@ -14,7 +14,7 @@ Get to know Nette Framework. We will create a simple blog with comments. Let's b
 
 \--
 
-After the first two chapters you will have your own working blog and you'll be ready to publish your awesome posts, although the features will be pretty much limited after completing these two chapters. To make things nicer for your users, you should also read following chapters and keep improving your application.
+After the first two chapters you will have your own working blog and you'll be ready to publish your awesome posts, although the features will be pretty much limited after completing these two chapters. To make things nicer for your users, you should also read the following chapters and keep improving your application.
 
 You can find the [complete application on GitHub |https://github.com/nette/quickstart]. The blog in this repository is a little bit more complex compared to what this tutorial covers, so be ready to learn.
 

--- a/en/quickstart/authentication.texy
+++ b/en/quickstart/authentication.texy
@@ -1,12 +1,12 @@
 Authentication
 **************
 
-Nette provides you with guidelines how to program authentication on your page, but it doesn't push you to do it any particular way. It's up to you how you want to implement it. Nette has an interface `Nette\Security\IAuthenticator`, which wants you to implement just a single method called `authenticate`, which finds the user anyhow you want.
+Nette provides you with guidelines how to program authentication on your page, but it doesn't force you to do it any particular way. The implementation is up to you. Nette has a `Nette\Security\IAuthenticator` interface which forces you to implement just a single method called `authenticate`, which finds the user anyhow you want.
 
 There are many ways how a user can authenticate himself. The most common way is *password-based authentication* (user provides his name or email and a password), but there are other means as well. You may be familiar with "Login with Facebook" buttons on many websites, or login via Google/Twitter/GitHub or any other site. With Nette, you can have any authentication method you want, or you can combine them. It's up to you.
 
 
-Normally you would write your own authenticator, but for this simple small blog, we can use one the `SimpleAuthenticator` which is bundled with Nette. It provides password-based authentication and the usernames and passwords are stored in config file. Add a *security* section to your `config.neon` (and don't forget to change the password):
+Normally you would write your own authenticator, but for this simple small blog, we can use the `SimpleAuthenticator` which is bundled with Nette. It provides password-based authentication and the usernames and passwords are stored in config file. Add a *security* section to your `config.neon` (and don't forget to change the password):
 
 
 /--neon
@@ -17,7 +17,7 @@ Normally you would write your own authenticator, but for this simple small blog,
 \--
 
 
-Nette will automatically create a service `authenticator` into DI Container.
+Nette will automatically create a service called `authenticator` in the DI container.
 
 .[note]
 You can read more about [Dependency Injection here |en/dependency-injection], and about [Configuration here |en/configuring]
@@ -32,10 +32,10 @@ We now have the backend part of authentication ready and we need to provide a us
 - authenticate the user when the form is submitted
 - provide log out action.
 
-What a coincidence, there is already one prepared in default sandbox! We can simply use it. So let's just go through it and check how it works.
+What a coincidence, there is already one prepared in the default sandbox! We can simply use it. So let's just go through it and check how it works.
 
 
-Let's start with the login form. You already know how form works in a presenter. Open up the `SignPresenter` and find method `createComponentSignInForm`. It should look like this
+Let's start with the login form. You already know how forms work in a presenter. Open up the `SignPresenter` and find method `createComponentSignInForm`. It should look like this:
 
 /--php
 	protected function createComponentSignInForm()
@@ -57,7 +57,7 @@ Let's start with the login form. You already know how form works in a presenter.
 	}
 \--
 
-There is a input for username and password. You can delete the `remember` checkbox if you like.
+There is an input for username and password. You can delete the `remember` checkbox if you like.
 
 
 View
@@ -76,13 +76,13 @@ The form is rendered in the template `app/templates/Sign/in.latte`
 Login Handler
 ----
 
-There is also prepared a *form handler* for for signing in the user, that gets invoked right after the form is submitted. The current handler also extends the time, for how long the user will be logged in, if he checks "remember", that's not needed right now, so let's delete it.
+There is also a *form handler* prepared for signing in the user, that gets invoked right after the form is submitted. The current handler also extends the time for how long the user will be logged in, if he checks "remember", that's not needed right now, so let's delete it.
 
-The handler will just take the username and password the user entered and will pass it to authenticator defined earlier. After the user has logged in, we will redirect him to the homepage.
+The handler will just take the username and password the user entered and will pass it to the authenticator defined earlier. After the user has logged in, we will redirect him to the homepage.
 
-There is a one more thing - the `try catch` statement. The method [User::login() | api:Nette\Security\User::login()] should throw an exception, when the username or password doesn't match those we've defined earlier. As we already know, that would result in a Tracy redscreen, or in production mode, into message informing about internal server error. We wouldn't like that. That's why we catch the exception and add nice and friendly error message to the form.
+There is one more thing - the `try catch` statement. The method [User::login() | api:Nette\Security\User::login()] should throw an exception when the username or password doesn't match those we've defined earlier. As we already know, that would result in a Tracy red-screen, or, in production mode, a message informing about internal server error. We wouldn't like that. That's why we catch the exception and add a nice and friendly error message to the form.
 
-When the error occurs in the form, the page with the form will be rendered again, and above the form, there will be a nice message, informing the user, that he or she have entered wrong username or password.
+When the error occurs in the form, the page with the form will be rendered again, and above the form, there will be a nice message, informing the user that they have entered a wrong username or password.
 
 /--php
 	public function signInFormSucceeded($form)
@@ -109,7 +109,7 @@ First of all, let's secure the form for creating new posts. It's defined in `Pos
 Presenter Views
 ---
 
-Let's create a action method `actionCreate` and if the user is not logged in, we will redirect him to sign in form and require authentication.
+Let's create an action method `actionCreate` that will redirect the user to the sign in form and require authentication if the user is not logged in.
 
 /--php
 	public function actionCreate()
@@ -135,7 +135,7 @@ Hide Links
 ----
 
 
-An unauthenticated user can not see the *create* nor *edit page*, but he can still see the links pointing to them. Let's hide those as well. One such link is in `app/templates/Homepage/default.latte`, and it should be visible only if the user is logged in.
+An unauthenticated user cannot see the *create* nor *edit page*, but he can still see the links pointing to them. Let's hide those as well. One such link is in `app/templates/Homepage/default.latte`, and it should be visible only if the user is logged in.
 
 We can hide it using *n:macro* called `n:if`. If the statement inside it is `false`, the whole `<a>` tag and it's contents will be not displayed
 
@@ -149,29 +149,31 @@ this is a shortcut for
 {if $user->loggedIn}<a n:href="Post:create">Create post</a>{/if}
 \--
 
+You should hide the edit link located in `app/templates/Post/show.latte` in a similar fashion.
+
 
 Form Handlers
 ---
 
-The last, and **the most important thing** is to **secure the form handler**. Because components are reusable, they can be rendered in several views. And because they can be rendered in several views, they can also be submitted from any such view, even the ones that do not really exist. This means, even if the view `create` is not rendered, by tweaking the url, some user can still submit the form (and add/edit posts).
+The last, and **the most important thing** is to **secure the form handler**. Because components are reusable, they can be rendered in several views. And because they can be rendered in several views, they can also be submitted from any such view, even the ones that do not really exist. This means, even if the view `create` is not rendered, by tweaking the url, a user can still submit the form (and add/edit posts).
 
 It can be prevented with a simple *if* that we will add at the beginning of `postFormSucceeded`
 
 /--php
-	public function postFormSucceeded(Form $form)
+	public function postFormSucceeded($form)
 	{
 		if (!$this->user->isLoggedIn()) {
 			$this->error('You need to log in to create or edit posts');
 		}
 \--
 
-It's simple as that, but you shall **never forget it**, it's really crucial for securing your app.
+It's simple as that, but you shall **never forget to do this** as it's really crucial for securing your app.
 
 
 Login Form Link
 ====
 
-Hey, but how do we get to the login page? There is no link pointing to it. Let's add one in the `app/templates/@layout.latte` template file. Try finding a nice place, it can be anywhere you like it most.
+Hey, but how do we get to the login page? There is no link pointing to it. Let's add one in the `app/templates/@layout.latte` template file. Try finding a nice place, it can be anywhere you like it the most.
 
 /--html
 <ul class="navig">
@@ -184,7 +186,7 @@ Hey, but how do we get to the login page? There is no link pointing to it. Let's
 </ul>
 \--
 
-If the user is not yet logged in, we will show the "Sign in" link. And if he already is, we will show the "Sign out" link. That action is also already in default sandbox and we can simply use it.
+If the user is not yet logged in, we will show the "Sign in" link. Otherwise, we will show the "Sign out" link. That action is also already defined in the default sandbox and we can simply use it.
 
 The logout action looks like this, and because we redirect the user immediately, there is no need for a view template.
 
@@ -197,10 +199,10 @@ The logout action looks like this, and because we redirect the user immediately,
 	}
 \--
 
-All it does, is to call the `logout()` method and then shows a nice message to the user.
+It just calls the `logout()` method and then shows a nice message to the user.
 
 
 Summary
 =======
 
-There is a `Sign in` link pointing to a new presenter, which asks the user for his passwords and authenticates him. We used *SimpleAuthenticator* and configured the usernames and passwords in config file, because it was very easy step and we don't need more users at the moment. We also secured all required actions and forms, so that only logged in users can add new posts or edit existing ones.
+There is a `Sign in` link pointing to a new presenter, which asks the user for his credentials and authenticates him. We used *SimpleAuthenticator* and configured the usernames and passwords in config file, because it was a very easy way and we don't need more users at the moment. We also secured all required actions and forms, so that only logged in users can add new posts or edit existing ones.

--- a/en/quickstart/comments.texy
+++ b/en/quickstart/comments.texy
@@ -1,18 +1,18 @@
 Comments
 ********
 
-The blog has been deployed, we’ve written some very good blog posts and published them via Adminer. People are reading the blog and they’re very passionate about our ideas. We’re receiving many emails with praise each day. But what is all the praise for when we’ve got it only in the email, so no one else can read it? Wouldn’t it be better, if people could comment directly on the blog so that everyone else could read how awesome we are?
+The blog has been deployed, we’ve written some very good blog posts and published them via Adminer. People are reading the blog and they’re very passionate about our ideas. We’re receiving many emails with praise each day. But what is all the praise for when we’ve got it only in the email, so no one else can read it? Wouldn’t it be better if people could comment directly on the blog so that everyone else could read how awesome we are?
 
 Let’s make all the articles commentable.
 
 
-Creating new Table
-==================
+Creating a new Table
+====================
 
 Fire up Adminer again and create a new table named `comments` with these columns:
 
 - `id` int, check autoincrement (AI)
-- `post_id`, foreign key, that refers the `posts` table
+- `post_id`, a foreign key that references the `posts` table
 - `name` varchar, length 255
 - `email` varchar, length 255
 - `content` text
@@ -30,7 +30,7 @@ Form for Commenting
 
 First, we need to create a form, that will allow the users to comment on our page. Nette Framework has awesome support for forms. They can be configured in a presenter and rendered in a template.
 
-Nette Framework has concept of *components*. A **component** is reusable class or piece of code, that can be attached to another component. Even a presenter is a component. Each component is created using the component factory. So let’s define the comments form factory in `PostPresenter`.
+Nette Framework has a concept of *components*. A **component** is a reusable class or piece of code, that can be attached to another component. Even a presenter is a component. Each component is created using the component factory. So let’s define the comments form factory in `PostPresenter`.
 
 /--php
 	protected function createComponentCommentForm()
@@ -51,11 +51,11 @@ Nette Framework has concept of *components*. A **component** is reusable class o
 	}
 \--
 
-Let’s explain it a little bit. The first line creates new instance of `Form` component.
+Let’s explain it a little bit. The first line creates a new instance of `Form` component.
 The following methods are attaching HTML inputs into the form definition.
-`->addText` will render as`<input type=text name=name>`, with `<label>Your name:</label>`. As you might have already guessed right now, the `->addTextArea` attaches an `<textarea>` and `->addSubmit` an `<input type=submit>`. There is more, but this is all you have to know right now. If you wanna know more right now, [you can read it in documentation|/forms].
+`->addText` will render as `<input type=text name=name>`, with `<label>Your name:</label>`. As you might have already guessed right now, the `->addTextArea` attaches a `<textarea>` and `->addSubmit` adds an `<input type=submit>`. There are more methods like that, but this is all you have to know right now. You can [learn more in the documentation|/forms].
 
-Once the form component is defined in a presenter, we can render (display) it in a template. To do so, place the macro `{control}` at the end of the template, of the post detail. It’s located at `app/templates/Post/show.latte`. Because the component is named `commentForm` (it’s in the name `createComponentCommentForm`), the macro will look like this
+Once the form component is defined in a presenter, we can render (display) it in a template. To do so, place the macro `{control}` at the end of the post detail template. It’s located at `app/templates/Post/show.latte`. Because the component's name is `commentForm` (it's derived from the name of the method `createComponentCommentForm`), the macro will look like this
 
 /--html
 <h2>Post new comment</h2>
@@ -63,7 +63,7 @@ Once the form component is defined in a presenter, we can render (display) it in
 {control commentForm}
 \--
 
-Now if you check out the detail of some post, there will be new form for posting comments rendered.
+Now if you check out the detail of some post, there will be a new form for posting comments.
 
 
 Saving to Database
@@ -99,9 +99,9 @@ It means "after the form is successfully submitted, call the method `commentForm
 
 You should place it right after the `commentsForm` component factory.
 
-The new method has one argument, and it’s the instance of the form being submitted, created by the component factory. We ask the form instance for its values, it has been submitted with, by calling `$form->getValues()`. And then we insert the data into database into table `comments`.
+The new method has one argument which is the instance of the form being submitted, created by the component factory. We ask the form instance for its submitted values by calling `$form->getValues()`. And then we insert the data into the database table `comments`.
 
-There are two more method calls to explain. The redirect literally redirects to the current page. You should do that every time, when the form is submitted, valid and the callback operation did what it should have done. Also, when you redirect the page after submitting the form, you won’t see the well known `Would you like to submit the post data again?` message, that you can sometimes see in the browser. (In general, after submitting a form by POST method, you should always redirect the user to an GET action.)
+There are two more method calls to explain. The redirect literally redirects to the current page. You should do that every time when the form is submitted, valid, and the callback operation did what it should have done. Also, when you redirect the page after submitting the form, you won’t see the well known `Would you like to submit the post data again?` message that you can sometimes see in the browser. (In general, after submitting a form by POST method, you should always redirect the user to a GET action.)
 
 The `flashMessage` is for informing the user about the result of some operation. Because we’re redirecting, the message cannot be directly passed to template and rendered. So there is this method, that will store it and make it available on the next page load. The flash messages are rendered in the default `app/templates/@layout.latte` file, and it looks like this
 
@@ -115,11 +115,11 @@ As we already know, they are passed automatically to the template, so you don’
 Rendering the Comments
 ======================
 
-This is one of the things you will just love. Nette\Database has this cool feature named *Selection API*. Do you remember, that we’ve created the tables as InnoDB? Adminer have created the so called [foreign keys |http://dev.mysql.com/doc/refman/5.5/en/innodb-foreign-key-constraints.html] that will save a ton of work.
+This is one of the things you will just love. Nette\Database has this cool feature named *Selection API*. Do you remember that we’ve created the tables as InnoDB? Adminer has created the so called [foreign keys |http://dev.mysql.com/doc/refman/5.5/en/innodb-foreign-key-constraints.html] that will save us a ton of work.
 
 Nette\Database uses the foreign keys to resolve relations between tables, and knowing the relations, it can automatically create queries for you.
 
-As you may remember, we’ve passed the `$post` variable to the template in `PostPresenter::renderShow()` and now we want to iterate through all the comments, that have the column `post_id` equal to our `$post->id`. You can do it by calling `$post->related('comments')`. It’s that simple. Look at the resulting code.
+As you may remember, we’ve passed the `$post` variable to the template in `PostPresenter::renderShow()` and now we want to iterate through all the comments that have the column `post_id` equal to our `$post->id`. You can do it by calling `$post->related('comments')`. It’s that simple. Look at the resulting code.
 
 /--php
 	public function renderShow($postId)
@@ -130,7 +130,7 @@ As you may remember, we’ve passed the `$post` variable to the template in `Pos
 	}
 \--
 
-And template:
+And the template:
 
 /--html
 <h2>Comments</h2>

--- a/en/quickstart/creating-posts.texy
+++ b/en/quickstart/creating-posts.texy
@@ -1,11 +1,11 @@
 Creating and Editing Posts
 **************************
 
-What a great time. We have a super cool new blog, people are arguing in comments and we have finally some time for more programming. Though we like Adminer, it is not that comfortable to write blog posts in it. Perhaps the right time to add a simple form for adding new posts directly from our app? Let’s do it.
+What a great time. We have a super cool new blog, people are arguing in comments and we have finally some time for more programming. Though we like Adminer, it is not that comfortable to write blog posts in it. Perhaps it's the right time to add a simple form for adding new posts directly from our app. Let’s do it.
 
 Let’s start by designing the UI:
 
-1. On the homepage, let’s add link "Write new post".
+1. On the homepage, let’s add a "Write new post" link.
 2. It will show a form with title and textarea for content.
 3. When you click a Save button, it’ll save the blog post.
 
@@ -20,7 +20,7 @@ Later we’ll also add authentication and allow only logged-in users to add new 
 Link for New Posts
 ===
 
-You should already know how to add a new link to homepage. So try it yourself.
+You should already know how to add a new link to the homepage. So try it yourself.
 
 If you’re not sure, add this code somewhere to `app/templates/Homepage/default.latte`:
 
@@ -32,7 +32,7 @@ If you’re not sure, add this code somewhere to `app/templates/Homepage/default
 Page for Creating a New Post
 ===
 
-The link we just created points to `PostPresenter` and its action `create`. We can add a new method `renderCreate`, but actually it is not necessary. We don’t need to fetch any data from database and put it into the template, so the method would be empty. In such case, it doesn’t need to exist at all.
+The link we've just created points to `PostPresenter` and its action `create`. We can add a new method `renderCreate`, but actually it is not necessary. We don’t need to fetch any data from database and put it into the template, so the method would be empty. In such case, it doesn’t need to exist at all.
 
 .[note]
 If you want, you can have the empty method there; perhaps it’ll have some code later. It’s up to you.
@@ -46,7 +46,7 @@ Let’s just create the template (`app/templates/Post/create.latte`):
 {control postForm}
 \--
 
-All the could should be obvious by now. The last line tries to render the form which we are about to create.
+Everything should be obvious by now. The last line tries to render the form which we are about to create.
 
 
 Form for Saving Posts
@@ -59,7 +59,7 @@ Now add this method to the `PostPresenter`:
 /---code php
 	protected function createComponentPostForm()
 	{
-		$form = new Form;
+		$form = new Nette\Application\UI\Form;
 		$form->addText('title', 'Title:')
 			->setRequired();
 		$form->addTextArea('content', 'Content:')
@@ -79,7 +79,7 @@ Saving new Post from Form
 Continue by adding a handler method.
 
 /---php
-	public function postFormSucceeded(Form $form)
+	public function postFormSucceeded($form)
 	{
 		$values = $form->getValues();
 		$post = $this->database->table('posts')->insert($values);
@@ -89,13 +89,13 @@ Continue by adding a handler method.
 	}
 \---
 
-Just a quick explanation, it fetches the values from form, inserts them into database, creates message for the user, that the post was saved successfully and redirects to page, where that post is published, so you can see, how it looks like.
+Just a quick explanation: it fetches the values from the form, inserts them into the database, creates a message for the user that the post was saved successfully, and redirects to the page where that post is published, so that you can see how it looks like.
 
 
 Editing Posts
 ===
 
-Let’s also add the capability to edit existing posts. It shall be pretty simple - we already have `postForm` and we can use it for editing as well. We’ll add a new `edit` page and update the form handler, which will be able either to add new posts (as it does now), or to edit existing ones.
+Let’s also add the capability to edit existing posts. It shall be pretty simple - we already have `postForm` and we can use it for editing as well. We’ll add a new `edit` page and update the form handler, which will be able either to add a new post (as it does now), or to edit existing ones.
 
 Add the method to the `PostPresenter`:
 
@@ -110,9 +110,9 @@ Add the method to the `PostPresenter`:
 	}
 \---
 
-Notice that the method is called `actionEdit` (and not `renderEdit`, as you may have expected). Render methods are for passing the data into template. Actions on the other hand may be doing a lot more, they should check if the page can be displayed by the current visitor or user and they should be doing most of the heavy work, that doesn't belong to form handlers. But, passing data into template would of course also work in action methods, but it's suggested not to do it, because of separating responsibilities. Your code is simply more synoptic when you split the code into render and action method.
+Notice that the method is called `actionEdit` (and not `renderEdit`, as you may have expected). Render methods are used for passing the data into templates. Actions, on the other hand, may be doing a lot more, they should check if the page can be displayed by the current visitor or user and they should be doing most of the heavy work, that doesn't belong to form handlers. Passing data into the template would of course also work in action methods, but it's recommended not to do it, because of separating responsibilities. Your code is simply more synoptic when you split the code into render and action methods.
 
-Now create a the template (`app/templates/Post/edit.latte`):
+Now create the template (`app/templates/Post/edit.latte`):
 
 /---html
 {block content}
@@ -143,10 +143,14 @@ Let’s also extend the form handler:
 
 When `postId` parameter is provided, it means that a post is being edited. In such case we’ll check that the post really exists and if so, we’ll update it in the database. If the `postId` is not provided, it means that a new post shall be added.
 
-But where does the `postId` come from? It is the parameter passed to `actionEdit` method.
+But where does the `postId` come from? It is the parameter passed to `actionEdit` method. You can now add a link to the `app/templates/Post/show.latte` template:
+
+/---html
+<a n:href="edit $post->id">Edit this post</a>
+\---
 
 
 Summary
 =======
 
-The blog is working, people are commenting rapidly and we no longer rely on Adminer for adding new posts. It is fully independent and even normal people can post there. But wait, that’s probably not ok, that anyone, I mean really anyone on the internet, can post on our blog. Some form of authentication is required, so that only logged-in users would be able to post. We'll add that in next chapter.
+The blog is working, people are commenting rapidly and we no longer rely on Adminer for adding new posts. It is fully independent and even normal people can post there. But wait, that’s probably not ok, that anyone, I mean really anyone on the Internet, can post on our blog. Some form of authentication is required, so that only logged-in users would be able to post. We'll add that in the next chapter.

--- a/en/quickstart/getting-started.texy
+++ b/en/quickstart/getting-started.texy
@@ -8,7 +8,7 @@ The very first thing you should do is check if your server satisfies the [requir
 
 You can download Nette Framework [manually |www:download], but the recommended way of starting a new project is using [Composer |/composer]. If you don't know Composer, you should definitely start with that. It's really simple, check out their [documentation |http://getcomposer.org/doc/].
 
-With Composer, you can download and install application skeleton known as Sandbox including Nette Framework very easily. To do so, find your web root directory (e.g. `/var/www` or `C:\InetPub`) in your command line and execute the following command:
+With Composer, you can download and install the application skeleton known as Sandbox including Nette Framework very easily. To do so, find your web root directory (e.g. `/var/www` or `C:\InetPub`) in your command line and execute the following command:
 
 /--code
 composer create-project nette/sandbox nette-blog
@@ -26,7 +26,7 @@ cd nette-blog && chmod -R a+rw temp log
 The Welcome Page
 ====
 
-At this moment, the welcome page of Sandbox should be running. Try it by opening your browser and going to the following URL:
+At this moment, the welcome page of the Sandbox should be running. Try it by opening your browser and going to the following URL:
 
 /--
 http://localhost/nette-blog/www/
@@ -65,20 +65,20 @@ Sandbox has the following structure:
 
 Directory `www` is supposed to store images, JavaScript, CSS, and other publicly available files. This is the only directory directly accessible from the browser, so you can point the root directory of your web server here (you can configure it in Apache, but let’s do it later as it’s not important right now).
 
-The most important directory for you is `app`. You can find `bootstrap.php` file there, which loads the framework and configures the application. It activates [autoloading |/auto-loading], sets up [routes |/routing] and starts the application.
+The most important directory for you is `app`. You can find `bootstrap.php` file there, which loads the framework and configures the application. It activates [autoloading |/auto-loading] and sets up the [debugger |/debugging] and [routes |/routing].
 
 
 
 Cleanup
 =======
 
-The sandbox contains some sample code. You should probably start by removing it before you write any of your own code - feel free to delete the `app/templates/Homepage/default.latte` file. We’ll add our own content in a minute.
+The sandbox contains some sample code. You should probably start by removing it before you write your own code - feel free to delete the `app/templates/Homepage/default.latte` file. We’ll add our own content in a minute.
 
 
 Tracy
 =====
 
-Extremely important tool for development is [debugger called Tracy |/en/debugging]. Try to make some errors in your `app/presenters/HomepagePresenter.php` file (e.g. remove a letter from word `class` in code) and see what happens. Red-screen page will occur with understandable error description.
+An extremely important tool for development is [a debugger called Tracy |/en/debugging]. Try to make some errors in your `app/presenters/HomepagePresenter.php` file (e.g. remove a letter from the word `class` in code) and see what happens. A red-screen page will pop up with understandable error description.
 
 [* debugger-620.png .(debugger screen) *]
 
@@ -99,6 +99,6 @@ After refreshing the web page, the red-screen page will be replaced with user-fr
 
 Now look into the `log` directory. You can find the error log there and also a red-screen page saved in an HTML file with name starting with `exception`.
 
-Comment line `$configurator->setDebugMode(FALSE);`. Tracy automatically enables debug mode on `localhost` environment and disables it elsewhere.
+Comment line `$configurator->setDebugMode(FALSE);` again. Tracy automatically enables debug mode on `localhost` environment and disables it elsewhere.
 
 Now, with the basic knowledge, we can start designing our application.

--- a/en/quickstart/home-page.texy
+++ b/en/quickstart/home-page.texy
@@ -11,10 +11,10 @@ Before we start, you should know at least some basics about Model-View-Presenter
 
 - **View** - a front-end definition layer. It renders requested data to the user using templates.
 
-- **Presenter** (or Controller) - a connection layer. Presenter connects Model and View. Handles requests, asks Model for data and then delegates them to the current View.
+- **Presenter** (or Controller) - a connection layer. Presenter connects Model and View. Handles requests, asks Model for data and then passes them to the current View.
 
 
-In case of a very simple application, like our blog is, the Model layer will actually consist only of the database itself - we don't need any extra PHP code for it. We only need to create a Presenter and a View. In Nette, each Presenter has its own Views, so we will continue with both simultaneously.
+In case of a very simple application like our blog, the Model layer will actually consist only of the database itself - we don't need any extra PHP code for it. We only need to create Presenter and View layers. In Nette, each Presenter has its own Views, so we will continue with both simultaneously.
 
 You can find the [source code on GitHub |https://github.com/nette/quickstart].
 
@@ -23,7 +23,7 @@ You can find the [source code on GitHub |https://github.com/nette/quickstart].
 Creating the Database with Adminer
 ==================================
 
-To store the data, we will use MySQL database, because it is the most common choice among web developers. But if you don’t like it, feel free to use database of your choice.
+To store the data, we will use the MySQL database, because it is the most common choice among web developers. But if you don’t like it, feel free to use a database of your choice.
 
 Let’s prepare the database which will store our blog posts. We can start very simply - just with a single table for posts.
 
@@ -43,7 +43,7 @@ It should look like this:
 [* adminer-posts.png *]
 
 .[tip]
-It’s very important to use the **InnoDB** table storage, you will see why later. For now, just choose that and submit. You can hit Save now.
+It’s very important to use the **InnoDB** table storage. You will see the reason later. For now, just choose that and submit. You can hit Save now.
 
 Try adding some sample blog posts before we implement the capability of adding new posts directly from our application. Actually, we wouldn't need to program adding / editing / removing posts, you could easily add new posts in Adminer and have the blog working.
 
@@ -52,9 +52,9 @@ Try adding some sample blog posts before we implement the capability of adding n
 Connecting to the Database
 ==========================
 
-Now, when the database is created and we have some posts pre-filled, it’s the right time to show them on our new shiny page.
+Now, when the database is created and we have some posts in it, it’s the right time to display them on our new shiny page.
 
-First, we need to tell our application which database to use. All the configuration, including the database configuration, is stored in `/app/config/config.neon`. Set the connection string DSN((Data Source Name)) and your credentials. It should look like this:
+First, we need to tell our application which database to use. All the configuration, including the database configuration, is stored in `/app/config/config.neon`. Set the connection DSN((Data Source Name)) and your credentials. It should look like this:
 
 /---neon
 	nette:
@@ -72,7 +72,7 @@ Be aware of indenting while editing this file. [NEON |http://ne-on.org] format a
 Injecting the Database Connection
 =============================
 
-The presenter (located in `app/presenters/HomepagePresenter.php`), which will be listing the articles, needs a database connection. To receive it, write a constructor like this:
+The presenter (located in `app/presenters/HomepagePresenter.php`), which will list the articles, needs a database connection. To receive it, write a constructor like this:
 
 /--php
 class HomepagePresenter extends BasePresenter
@@ -84,6 +84,10 @@ class HomepagePresenter extends BasePresenter
 	{
 		$this->database = $database;
 	}
+
+	// ...
+
+}
 \--
 
 
@@ -91,7 +95,7 @@ class HomepagePresenter extends BasePresenter
 Loading Posts from the Database
 ===============================
 
-Now let’s fetch the posts from the database and pass them to template, which will then render the HTML code. This is what the so called *render* method is for
+Now let’s fetch the posts from the database and pass them to the template, which will then render the HTML code. This is what the so called *render* method is for
 
 /--php
 	public function renderDefault()
@@ -102,13 +106,13 @@ Now let’s fetch the posts from the database and pass them to template, which w
 	}
 \--
 
-The presenter now has one render method `renderDefault()` that passes data to a view called `default`. Presenter templates can be found in `app/templates/{PresenterName}/{viewName}.latte`, so in this case the template will be located in `app/templates/Homepage/default.latte`. In the template, a variable `$posts` is now available.
+The presenter now has one render method `renderDefault()` that passes data to a view called `default`. Presenter templates can be found in `app/templates/{PresenterName}/{viewName}.latte`, so in this case the template will be located in `app/templates/Homepage/default.latte`. In the template, a variable named `$posts` is now available.
 
 
 Template
 ========
 
-There is a generic template for the whole page (called *layout*, with header, stylesheets, footer, ...) and then concrete templates for each view (e.g. for displaying the list of blog posts), which can override some of layout template parts.
+There is a generic template for the whole page (called *layout*, with header, stylesheets, footer, ...) and then specific templates for each view (e.g. for displaying the list of blog posts), which can override some of layout template parts.
 
 By default, the layout template is located in `app/templates/@layout.latte`, which contains
 
@@ -116,7 +120,7 @@ By default, the layout template is located in `app/templates/@layout.latte`, whi
 {include #content}
 \--
 
-This line includes a named block called `#content`, which is defined in a concrete template.
+This line includes a named block called `#content`, which is defined in the specific template.
 
 You can try to refresh your browser now, even though you haven’t created the template yet. Nette will display an error message:
 
@@ -130,7 +134,7 @@ Now, create the missing file and insert the minimum required code:
 {block #content}
 \--
 
-This means that we’re defining the *content* block, which will be inserted into the layout. If you refresh the browser, you’ll see an empty page (with only HTML header and footer).
+It defines the *content* block, which will be inserted into the layout. If you refresh the browser, you’ll see an empty page (with only HTML header and footer).
 
 Let’s display the blog posts - add the following code to the template, after the block definition:
 
@@ -154,9 +158,9 @@ The `{foreach}` macro iterates over all posts passed to the template in `$posts`
 
 The `{link}` macro generates a URL which leads to the `Post:show` action (which we are about to create). It also passes ID of the post as an argument. We’ll get to it in a minute.
 
-The `|date:` thing is called a helper. Helpers are used to format value of variables. This one transforms the timestamp (e.g. `2013-04-12`) to nice and readable date format (`April 12, 2013`). You can find more existing "helpers":/default-helpers in the documentation or you can add your own if you need to.
+The `|date:` thing is called a helper. Helpers are used to format the output. This one transforms the given timestamp (e.g. `2013-04-12`) to a nice and readable date format (`April 12, 2013`). You can find more predefined "helpers":/default-helpers in the documentation or you can add your own if you need to.
 
-One more thing. We can make the code a little bit shorter and thus simpler. We can replace *Latte macros* with *n: attributes* like this
+One more thing. We can make the code a little bit shorter and thus simpler. We can replace *Latte macros* with *n: attributes* like this:
 
 /--html
 <div n:foreach="$posts as $post" class="post">
@@ -168,7 +172,7 @@ One more thing. We can make the code a little bit shorter and thus simpler. We c
 </div>
 \--
 
-The `n:foreach`, simply wraps the *div* with a *foreach* block (it does exactly the same as the previous block of code).
+The `n:foreach`, simply wraps the *div* with a *foreach* block (it does exactly the same thing as the previous block of code).
 
 The `n:href` attribute is an alias for the `{link}` macro.
 
@@ -176,4 +180,4 @@ The `n:href` attribute is an alias for the `{link}` macro.
 Summary
 =======
 
-We have a very simple MySQL database with some blog posts already created. The application connects to the database and displays the posts in a simple list.
+We have a very simple MySQL database with some blog posts in it. The application connects to the database and displays a simple list of the posts.

--- a/en/quickstart/single-post.texy
+++ b/en/quickstart/single-post.texy
@@ -2,10 +2,10 @@ Single Post Page
 ****************
 
 .[perex]
-Let’s add another page to our blog, which will display content of one particular blog post.
+Let’s add another page to our blog, which will display the content of one particular blog post.
 
 
-We need to create new render method, that will fetch one concrete blog post, and pass it to the template. Having this view in `HomepagePresenter` is not nice, because it’s about a blog post, not homepage. So, let’s create a new class `PostPresenter` and place it to `app/presenters/PostPresenter.php`. It will need a database connection, so put the *database injection* code there again.
+We need to create a new render method, that will fetch one specific blog post and pass it to the template. Having this view in `HomepagePresenter` is not nice, because it’s about a blog post, not homepage. So, let’s create a new class `PostPresenter` and place it to `app/presenters/PostPresenter.php`. It will need a database connection, so put the *database injection* code there again.
 
 The `PostPresenter` should look like this:
 
@@ -29,7 +29,7 @@ class PostPresenter extends BasePresenter
 
 The `renderShow` method requires one argument - the ID of the post to be displayed. Then, it loads the post from the database and passes the result to the template.
 
-In the `app/templates/Homepage/default.latte` template, we’ve already created a link to the `Post:show` action, for which a template doesn’t exist yet. You can try to view a post in your browser using the link in the list on the home page. [Tracy | /debugging] will show an error, because the `app/templates/Post/show.latte` template has not yet been created. So let’s add that one as well:
+In the `app/templates/Homepage/default.latte` template, we’ve already created a link to the `Post:show` action, for which a template doesn’t exist yet. You can try to open a post in your browser using the link in the list on the home page. [Tracy | /debugging] will show an error, because the `app/templates/Post/show.latte` template has not yet been created. Let’s add that one now:
 
 /--html
 {block #content}
@@ -45,13 +45,13 @@ In the `app/templates/Homepage/default.latte` template, we’ve already created 
 
 Let’s have a look at the individual parts.
 
-The first line starts the definition of a *named block* called "content" we saw earlier, which will be displayed in a *layout template*.
+The first line starts the definition of a *named block* called "content" that we saw earlier. It will be displayed in a *layout template*.
 
 The second line provides a back link to the list of blog posts, so the user can navigate smoothly back and forth on our blog. We use `n:href` attribute again, therefore Nette will take care of generating the URL for us. The link points to the `default` action of the `Homepage` presenter (you could also write `n:href="Homepage:"` as the `default` action can be omitted).
 
 The third line formats the publication timestamp with a helper, as we already know.
 
-The fourth line displays the *title* of the blog post into a heading `<h1>`. There is a part that you may not be familiar with, and that is `n:block="title"`. Can you guess what it does? If you’ve read carefully the previous parts, we've mentioned `n: attributes`. This is another example. It is an equivalent to:
+The fourth line displays the *title* of the blog post as an `<h1>` heading. There is a part that you may not be familiar with, and that is `n:block="title"`. Can you guess what it does? If you’ve read the previous parts carefully, we've mentioned `n: attributes`. This is another example. It is equivalent to:
 
 /--html
 {block #title}<h1>{$post->title}</h1>{/block}
@@ -80,10 +80,10 @@ What happens if someone alters the URL and inserts `postId` which does not exist
 	}
 \--
 
-If the post cannot be found, calling `$this->error(...)` will show a 404 page with a nice and understandable message. Note, that in your development environment (on your laptop), you won’t see the error page, instead Tracy will show the exception with full details. This is pretty convenient for development. You can check both modes, just change value passed to `setDebugMode` in `bootstrap.php`.
+If the post cannot be found, calling `$this->error(...)` will show a 404 page with a nice and understandable message. Note, that in your development environment (on your laptop), you won’t see the error page. Instead, Tracy will show the exception with full details. This is pretty convenient for development. You can check both modes, just change the value passed to `setDebugMode` in `bootstrap.php`.
 
 
 Summary
 =======
 
-We have a database with blog posts and a web app with two views - first to show summary of all recent posts and second one to display one concrete post.
+We have a database with blog posts and a web app with two views - first one displays the summary of all recent posts and the second one displays one specific post.


### PR DESCRIPTION
Changes:
- some grammar and style corrections,
- removed typehints from form handlers as there are no corresponding `use` statements in the quickstart text,
- added 'edit post' link.
