### PR TITLE
Odebrání odkazu na špatné místo

### DIFF
--- a/cs/default-macros.texy
+++ b/cs/default-macros.texy
@@ -68,7 +68,7 @@ Zajímají vás bližší informace o [syntaxi Latte |templating#latte] nebo o [
 | `{block #block}`               | [definuje a hned vykreslí blok |#bloky]
 | `{define #block}`              | [definuje blok pro pozdější použití |#bloky]
 | `{include #block}`             | [vloží blok |#Vkládání bloků]
-| `{includeblock 'file.latte'}`  | [načte bloky z externí šablony |#rozšiřování a dědičnost]
+| `{includeblock 'file.latte'}`  | načte bloky z externí šablony
 | `{layout 'file.latte'}`        | [určuje soubor s layoutem |#rozšiřování a dědičnost]
 | `{extends 'file.latte'}`       | [alias pro {layout} |#rozšiřování a dědičnost]
 | `{ifset #block} … {/ifset}`    | [podmínka, zda existuje blok |#bloky]


### PR DESCRIPTION
Chybí informace o funkčnosti includeblock, tedy nemá smysl posílat čtenáře na nesouvisející místo do textu.
