### PR TITLE
"Migrating to version 2.1" typos

### DIFF
--- a/en/migration-2-1.texy
+++ b/en/migration-2-1.texy
@@ -186,7 +186,7 @@ Latte
 - shorter macro for blocks `{#block}` (present in development version) was not included in version 2.1 due to comprehension reasons
 - native support for empty macros, use for example `{label foo /}` instead of `{label foo}`
 
-Latte contains a new feature which automatically checks if variable `$url` in `<a href={$url}>` contains malicious code (like `javascript:siteHack()`). It only allows http, https, ftp, mailto protocols and relative paths. It also checks in attributes src, action, formaction and `<object data=...>`. Should you need to print URL without checking, use `|nosafeurl` modificator.
+Latte contains a new feature which automatically checks if variable `$url` in `<a href={$url}>` contains malicious code (like `javascript:siteHack()`). It only allows http, https, ftp, mailto protocols and relative paths. It also checks in attributes src, action, formaction and `<object data=...>`. Should you need to print URL without checking, use `|nosafeurl` modifier.
 
 There also was a small change with manual rendering of checkboxes, which is described later in the article.
 
@@ -203,7 +203,7 @@ Macro `{control form}` always prints error messages next to controls; only unass
 - controls marked `setDisabled()` are not present in `$form->getValues()` (they are not sent by the browser)
 - deprecated `SelectBox::setPrompt(TRUE)`; use string instead of TRUE
 - renamed `MultiSelectBox::getSelectedItem()` -> `getSelectedItems()`
-- HTML atributtes as `data-nette-rules` contains JSON, don't forget to update `netteForms.js` to latest version
+- HTML attributes as `data-nette-rules` contains JSON, don't forget to update `netteForms.js` to latest version
 - Form: removed deprecated event `$onInvalidSubmit`, use `$onError` instead
 - RadioList: calling `getValue(TRUE)` is deprecated, use `getRawValue()` instead
 
@@ -231,7 +231,7 @@ miscellaneous
 - loader doesn't set `iconv_set_encoding()` and `mb_internal_encoding()` anymore
 - deprecated constants `NETTE, NETTE_DIR and NETTE_VERSION_ID`
 - deprecated class `Nette\Loaders\AutoLoader`
-- depecated variable `Nette\Framework::$iAmUsingBadHost`
+- deprecated variable `Nette\Framework::$iAmUsingBadHost`
 - we recommend you to stop using `callback()` and class `Nette\Callback`, because global functions can cause "troubles":https://github.com/nette/nette/issues/1187
 - renamed namespace `Nette\Utils\PhpGenerator` -> `Nette\PhpGenerator`
 - Nette shows warning „Possible problem: you are sending a cookie while already having some data in output buffer,“ if you are trying to send HTTP headers or cookies and previous output was sent to buffer. The error is shown because buffer may overflow.


### PR DESCRIPTION
I found some typos.

@fprochazka I agree, https://github.com/nette/web-content/pull/35 had better English, but you were fast&furious :wink: and made some mistakes (which were fixed in https://github.com/nette/web-content/pull/37) while merging them together.
