### PR TITLE
Typo in selecting language

### DIFF
--- a/cs/quickstart/authentication.texy
+++ b/cs/quickstart/authentication.texy
@@ -19,7 +19,7 @@ Obyčejně bychom si nejspíš napsali vlastní authenticator, ale pro tento jed
 Nette automaticky vytvoří službu s názvem `authenticator` v DI kontejneru.
 
 .[note]
-Více si můžete přečíst o [Dependency Injection zde |en/dependency-injection] a o [konfiguraci zde |en/configuring]
+Více si můžete přečíst o [Dependency Injection zde |cs/dependency-injection] a o [konfiguraci zde |cs/configuring]
 
 
 Přihlašovací formulář


### PR DESCRIPTION
I found a typo at link to information about Dependency injection and Configuration
