### PR TITLE
default-macros: added {include parent}

### DIFF
--- a/cs/default-macros.texy
+++ b/cs/default-macros.texy
@@ -563,6 +563,14 @@ V bloku lze vložit i sebe sama, což lze použít např. pro vykreslení stromo
 Místo `{include menu, ...}` lze psát také `{include this, ...}`.
 
 
+Pokud je potřeba doplnit již definovaný blok (např. přidání nových stylů), není kvůli tomu potřeba kopírovat celý obsah tohoto bloku. Místo toho si nadefinujte nový (stejně pojmenovaný) blok a uvnitř zavolejte `{include parent}`.
+
+/--html
+{block styles}
+    {include parent}
+    <link href="http://url.to.styles.css" rel="stylesheet">
+{/block}
+ \--
 
 
 Rozšiřování a dědičnost šablon `{layout}` .{toc: Rozšiřování a dědičnost}

--- a/en/default-macros.texy
+++ b/en/default-macros.texy
@@ -529,6 +529,14 @@ Blocks can also include themselves which is suitable when rendering a tree struc
 Instead of `{include menu, ...}` we can write `{include this, ...}` where #this points to the current block.
 
 
+If you need to add some code to the previously defined block (e.g. add a link to a new stylesheet), you don't need to redeclare and copy whole block. Use `{include parent}` instead.
+
+/--html
+{block styles}
+    {include parent}
+    <link href="http://url.to.styles.css" rel="stylesheet">
+{/block}
+ \--
 
 
 Template expanding/inheritance `{layout}` .{toc: Template expanding/inheritance}


### PR DESCRIPTION
Really handy macro for including block's previous definiion. This is very nice when you need to extend an existing block with a few new lines (e.g. include a new stylesheet)
