### PR TITLE
nette.org: rewrite of en/writing and cs/writing

### DIFF
--- a/www/cs/writing.texy
+++ b/www/cs/writing.texy
@@ -16,7 +16,7 @@ Dokumentace je určena především lidem, kteří se s tématem teprve seznamuj
 - Buďte struční - co napíšete, zkraťte na polovinu. A pak klidně ještě jednou.
 - Snažte se věc co nejlépe vysvětlit. Zkuste například téma nejprve vysvětlit kolegovi.
 
-Tyto body mějte na paměti po celou dobu psaní. Další tipy naleznete v článku "Píšeme pro web":[http://www.lupa.cz/clanky/piseme-pro-web/]. Dokumentace je psaná v Texy!:[http://texy.info/cs/], proto se naučte jeho [wiki:syntax].
+Tyto body mějte na paměti po celou dobu psaní. Další tipy naleznete v článku "Píšeme pro web":[http://www.lupa.cz/clanky/piseme-pro-web/]. Dokumentace je psaná v "Texy!":[http://texy.info/cs/], proto se naučte jeho [wiki:syntax]. Pro náhled článku během jeho psání můžete použít editor dokumentace na adrese [http://editor.nette.org/].
 
 Kromě výše uvedených bodů také dodržujte následující zásady:
 
@@ -56,7 +56,7 @@ Pro přispívání do dokumentace je nutné mít účet na [github.com] a znát 
 
 Pokud se rozhodnete do dokumentace přispět, nejdříve si vytvořte fork již zmíněného repositáře "nette/web-content":[https://github.com/nette/web-content] a repositář si naklonujte na svůj počítač.
 
-Poté v příslušné větvi proveďte změny, změnu commitněte, pushnetě do svého repositáře na github.com a pošlete pull request do původního repositáře `nette/web-content`. Pamatujte, že hlavním jazykem dokumentace je angličtina, změny proto provádějte v obou jazycích.
+Poté v příslušné větvi proveďte změny, změnu commitněte, pushněte do svého repositáře na github.com a pošlete pull request do původního repositáře `nette/web-content`. Pamatujte, že hlavním jazykem dokumentace je angličtina, změny proto provádějte v obou jazycích.
 
 
 {{themeicon: icon-art-and-painting.png}}

--- a/www/en/writing.texy
+++ b/www/en/writing.texy
@@ -16,7 +16,7 @@ The main audience of the documentation is people who are new to the topic. The t
 - Be concise. Halve you text, then halve it again.
 - Be explanatory. Try explaining the topic to your colleague first.
 
-Keep these rules in mind when you are writing. The documentation is written in "Texy!":[http://texy.info/en/], so have a look at its [wiki:syntax].
+Keep these rules in mind when you are writing. The documentation is written in "Texy!":[http://texy.info/en/], so have a look at its [wiki:syntax]. You can use documentation editor at [http://editor.nette.org/] to preview your article. This editor also provides live preview.
 
 Among the general writing rules listed earlier, please stick to the following:
 


### PR DESCRIPTION
Pages `cs/writing` and `en/writing` were updated.

The text begins with helpful information on writing, followed by structure of the github repositories. I also tried to provide a link to a simple git tutorial and outline the basic git workflow for people who are not familiar with git.

Any feedback is welcomed.
