### PR TITLE
doc-2.1: Getting dependencies (new page)

### DIFF
--- a/cs/di-usage.texy
+++ b/cs/di-usage.texy
@@ -1,0 +1,437 @@
+Získávání závislostí
+********************
+
+/--div .[perex]
+Existuje několik možností, jakým do presenterů, komponent a služeb můžeme dostat (injektovat) jejich závislosti. V tomto článku probereme:
+
+* obecné možnosti získávání závislostí, nejen těch z "DI Containeru":[dependency-injection] v Nette a
+* konkrétní příklady a doporučení pro presentery, komponenty a služby.
+\--
+
+
+Jak získávat závislosti?
+========================
+
+Závislosti je možné do aplikačních tříd získávat čtyřmi hlavními způsoby:
+
+* předávání konstruktorem,
+* předávání setterem nebo nastavením členské proměnné,
+* metodou `inject*` 
+* anotací `@inject` u proměnné s typem přístupu `public`.
+
+První dva způsoby platí obecně ve všech objektově orientovaných jazycích, zbylé jsou specifické pro Nette. Nyní si jednotlivé možnosti přiblížíme a poté přejdeme k jejich aplikaci v konkrétních případech.
+
+
+Předávání konstruktorem
+-----------------------
+
+Závislosti, které se předávají v okamžiku vytváření objektu. Závislost je deklarována jako parametr konstruktoru a její typ je uveden jako Type Hint:
+
+/--php
+class MyService
+{
+	/** @var AnotherService */
+	private $anotherService
+
+	public function __construct(AnotherService $service) {
+		$this->anotherService = $service;
+	}
+}
+\--
+
+Třída `MyService` takto deklaruje, že při vytváření objektu jí musí být předána instance třídy `AnotherService`. Tato deklarace závislostí je vhodná pro povinné závislosti, které třída nezbytně potřebuje ke své funkci, neboť bez ní nepůjde instanci vytvořit.
+
+
+Předávání setterem či nastavením proměnné
+-----------------------------------------
+
+Tyto závislosti jsou předávány až po vytvoření objektu. Nejprve uveďme příklad nastavení závislosti setterem. Typ požadované závislosti je uveden jako Type Hint:
+
+/--php
+class MyService
+{
+	/** @var AnotherService */
+	private $anotherService
+		
+	public function setAnotherService(AnotherService $service)
+	{
+		$this->anotherService = $service;
+	}
+}
+\--
+
+Objektu je možné závislost předat až po jeho vytvoření. Tento způsob je vhodný pouze pro nepovinné závislosti, které nejsou pro funkci třídy nezbytné, neboť není garantováno, že objekt závislost skutečně dostane.
+
+Podobně pak bude fungovat nastavení členské proměnné:
+
+/--php
+class MyService
+{
+	/** @var AnotherService */
+	public $anotherService;
+}
+\--
+
+Tento způsob je však nevhodný, neboť členská proměnná musí být deklarována jako `public`, a tudíž nemáme kontrolu nad tím, že předaná závislost bude skutečně daného typu. Přicházíme také o možnost reagovat na nově přiřazenou závislost vlastním kódem a porušujeme také princip zapouzdření.
+
+Tímto způsobem se tedy nebudeme dále zabývat.
+
+Předávání metodou `inject*`
+---------------------------
+
+Tento způsob je specifický pro DI Container v Nette. Jedná se o zvláštní případ setteru, metoda začíná prefixem `inject`. 
+
+/--php
+class MyService
+{
+	/** @var AnotherService */
+	public $anotherService;
+	
+	public function injectAnotherService(AnotherService $service)
+	{
+		$this->anotherService = $service;
+	}
+}
+\--
+
+Metod `inject*` může třída obsahovat několik a každá může mít více parametrů. Každá metoda musí mít samozřejmě unikátní název.
+
+Základní rozdíl od setteru je ten, že Nette je takto pojmenovanou metodu schopné v presenterech najít a automaticky zavolat se správnými parametry. U služeb lze vyhledání a nalezení vynutit konfigurací - bude vysvětleno dále.
+
+Anotace `@inject`
+-----------------
+
+Další způsob specifický pro DI Container v Nette. Jedná se o zvláštní případ závislostí předávaných pomocí public proměnné, tentokrát je však proměnná označena anotací `@inject` v dokumentačním komentáři. Typ předávané závislosti je uveden v dokumentačním komentáři:
+
+/--php
+class MyService
+{
+	/** @inject @var \App\AnotherService */
+	public $anotherService;
+}
+\--
+
+Nette opět může takto anotovanou proměnnou najít a automaticky závislost injektovat. Jako typ třídy musí být uveden její plný název včetně celého namespace. Od verze Nette 2.2 lze využít aliasů definovaných pomocí direktiv `use`.
+
+Tento způsob má podobné nedostatky, jako předávání závislosti do veřejné proměnné - opět nelze vynutit typ předávané třídy a musíme se spolehnout na to, že bude předána instance správné třídy.
+
+V některých případech však může jít o vhodnou variantu, neboť nekomplikuje kód a vyžaduje jen minimum psaní navíc.
+
+Jaký způsob zvolit?
+===================
+
+Předávání závislostí pomocí konstruktoru je dostupné u všech vytvářených tříd, podobně pak použití setteru u nepovinných závislostí. Další techniky, tedy metody `inject*` a členské proměnné označené anotací `@inject`, jsou pak méně čisté techniky a jsou dostupné jen v presenterech, případně je možné je vynutit konfigurací u služeb vytvářených DI Containerem. Používáme je tedy pouze ve specifických případech, například u již zmíněných presenterů.
+
+Pro všechny způsoby je společné, že [automatické dosazování závislostí (auto-wiring) | configuring#auto-wiring] funguje pouze u objektů, které Nette vytváří automaticky prostřednictvím DI Containeru nebo továren. Pokud objekt vytváříme voláním `new` ve vlastním kódu, musíme závislosti vždy předat sami.
+
+Nyní se podíváme na jednotlivé příklady a uvedeme preferovaný způsob předávání závislostí.
+
+Presentery
+----------
+
+Presentery vytváří Nette Framework automaticky prostřednictvím příslušné továrny, která i zajišťuje předání příslušných závislostí. Automaticky jsou předány:
+
+1) závislosti uvedené v konstruktoru,
+2) závislosti voláním metod `inject*`,
+3) závislosti předané do proměnných s anotací `@inject`.
+
+Následující presenter ilustruje všechny tři způsoby předávání:
+
+/--php
+class MyPresenter extends Nette\Application\UI\Presenter
+{	
+	// 1) Předání konstruktorem:
+	private $service1;
+	
+	public function __construct(Service1 $service)
+	{
+		$this->service1 = $service;
+	}
+	
+	// 2) Předání metodou inject*:
+	private $service2;
+	
+	public function injectService2(Service2 $service)
+	{
+		$this->service2 = $service;
+	}
+	
+	// 3) Předání do proměnné s anotací @inject:
+	/** @inject @var \App\Service3 */
+	public $service3;
+}
+\--
+
+Preferovaný způsob předávání závislostí je pomocí anotace `@inject`, neboť nekomplikuje kód a Nette se o předání správné závislosti stará automaticky.
+
+Pokud potřebujete přesně definovat kontrakt presenteru (může být vhodné například pro testování), použijte metody `inject*`.
+
+Předávání pomocí konstruktoru je spíše nedoporučované, protože při dědění presenterů je nutné získávat závislosti i všech rodičovských presenterů a to komplikuje signaturu konstruktoru.
+
+Komponenty
+----------
+
+Komponenty jsou typicky vytvářeny přímo v kódu presenteru, nebo prostřednictvím továren, které jsou specifické pro danou aplikaci. V těchto případech Nette nemůže závislosti automaticky předat a není možné použít metody `inject*`, ani anotaci `@inject`.
+
+Uvažujme následující komponentu:
+
+/--php
+class MyControl extends Nette\Application\UI\Control
+{
+	// 1) Předání konstruktorem:
+	private $service1;
+	
+	public function __construct(Service1 $service)
+	{
+		parent::__construct();
+		$this->service1 = $service;
+	}
+	
+	// 2) Předání setterem:
+	private $service2;
+	
+	public function setService2(Service2 $service)
+	{
+		$this->service2 = $service;
+	}
+}
+\--
+
+Její použití v presenteru by vypadalo následovně:
+
+/--php
+class MyPresenter extends Nette\Application\UI\Presenter
+{
+	/** @inject @var \App\Service1 */
+	private $service1;
+	/** @inject @var \App\Service2 */
+	private $service2;
+	
+	protected function createCompoonentMyControl()
+	{
+		$control = new MyControl($this->service1);
+		$control->setService2($this->service2);
+		return $control;
+	}
+}
+\--
+
+Protože závislosti nejsou z DI Containeru předávány automaticky, musíme je získat ve třídě, která danou komponentu vytváří. V našem případě jde o presenter. Pokud bychom komponentu vytvářeli v jiné komponentě, musíme její závislosti přidat k závislostem rodičovské komponenty:
+
+/--php
+class MySecondControl extends Nette\Application\UI\Control
+{
+	// Závislost pro MySecondControl:
+	private $service3;
+	// Závislosti pro vnořenou MyControl:
+	private $service1;
+	private $service2;
+	
+	public function __construct(Service1 $service1, Service2 $service2,
+	                            Service3 $service3)
+	{
+		public::__construct();
+		// přiřazení do členských proměnných $service1, $service2, $service3
+	}
+	
+	protected function createCompoonentMyControl()
+	{
+		$control = new MyControl($this->service1);
+		$control->setService2($this->service2);
+		return $control;
+	}
+}
+\--
+
+Protože instance komponent typicky vytváříme ručně, je preferovaný způsob předávání závislostí závislý na tom, zda je závislost povinná nebo není. V případě povinných závislostí použijeme konstruktor, v případě nepovinných setter.
+
+.[caution]
+Pozor, v případě předávání do konstruktoru nesmíme zapomenout na volání konstruktoru rodiče: `parent::__construct()`!
+
+Služby
+------
+
+Služby jsou registrovány v DI Containeru a závislosti jsou tedy předávány automaticky. Pokud neuvedeme dodatečnou konfiguraci, budou předány pouze závislosti pomocí konstruktoru:
+
+/--code neon
+services:
+	service1: App\Service1
+\--
+
+Takto definované službě budou při vytváření automaticky předány všechny závislosti uvedené v konstruktoru:
+
+/--php
+class Service1
+{
+	private $anotherService;
+	
+	public function __construct(AnotherService $service)
+	{
+		$this->anotherService = $service;
+	}
+}
+\--
+
+Předávání konstruktorem je preferovaný způsob pro služby.
+
+Pokud chceme předávat závislosti pomocí setteru, můžeme definici služby rozšířit o sekci `setup`:
+
+/--code neon
+services:
+	service2:
+		class: App\Service2
+		setup:
+			- setAnotherService
+\--
+
+Třída služby:
+
+/--php
+class Service2
+{
+	private $anotherService;
+	
+	public function setAnotherService(AnotherService $service)
+	{
+		$this->anotherService = $service;
+	}
+}
+\--
+
+Uvedením konfigurační direktivy `inject: yes` pak můžeme zapnout i automatické volání metod `inject*` a předávání závislostí do členských proměnných označených anotací `@inject`:
+
+/--code neon
+services:
+	service3:
+		class: App\Service3
+		inject: yes
+\--
+
+Závislost `Service1` bude předána voláním metody `inject*`, závislost `Service2` bude přiřazena do proměnné `$service2`:
+
+/--php
+class Service3
+{
+	// 1) Metoda inject*:
+	private $service1;
+	
+	public function injectService1(Service1 $service)
+	{
+		$this->service1 = $service1;
+	}
+	
+	// 2) Přiřazení do proměnné s anotací @inject:
+	/** @inject @var \App\Service2 */
+	public $service2;
+}
+\--
+
+
+Další možnosti
+==============
+
+Existuje několik dalších možností, jak ovlivnit konfiguraci a předávání závislostí pro presentery a komponenty.
+
+Presenter jako služba
+---------------------
+
+Od Nette verze 2.1 je možné presenter zaregistrovat jako službu do konfiguračního souboru. Při jeho vytváření se však postupuje stejně, jako u libovolné jiné služby. Je tedy možné předat presenteru i parametry, které nelze dosadit pomocí autowire, a přidat volání setterů.
+
+Volání metod `inject*` a předávání závislostí do členských proměnných s anotací `@inject` se vykoná vždy, není tedy nutné uvádět v konfiguraci `inject: yes`.
+
+Definice presenteru může vypadat například takto:
+
+/--code neon
+services:
+	- App\Presenters\ImagePresenter("%wwwDir%/media")
+\--
+
+/--php
+class ImagePresenter extends Nette\Application\UI\Presenter
+{
+	private $imageDir;
+	private $optimizer;
+
+	public function __construct($imageDir, ImageOptimizer $optimizer)
+	{
+		$this->imageDir = $imageDir;
+		$this->optimizer = $optimizer;
+	}
+}
+\--
+
+Presenteru se pak jako první parametr konstruktoru předá uvedený řetězec, zbylé parametry se doplní pomocí autowire.
+
+Při navrhování presenterů však buďte opatrní a dbejte na to, aby v nich nebyla obsažena aplikační logika, která patří do služeb. Pokud potřebujete presenter dodatečně konfigurovat, často to bývá známkou toho, že nemáte problém dostatečně dekomponovaný.
+
+
+Továrna na komponenty
+---------------------
+
+Podobně jako presentery, i komponenty můžeme zaregistrovat v konfiguračním souboru. Avšak zatímco u presenteru se dá očekávat, že bude existovat v průběhu vyřizování celého požadavku pouze jeden, komponent může být víc. Proto místo registrace jako služby použijeme továrnu.
+
+Od Nette 2.1 je možné používat továrny generované proti rozhraní. U rozhraní stačí u příslušných metod uvést anotaci `@return`, která říká, instanci jaké třídy má továrna vytvářet. Nette pak pro rozhraní vygeneruje správnou implementaci.
+
+Rozhraní musí mít právě jednu metodu pojmenovanou `create`. Naše rozhraní pro komponentu může vypadat například takto:
+
+/--php
+namespace App\Components;
+
+interface IUserTableFactory
+{
+	/**
+	 * @return UserTable
+	 */
+	public function create();
+}
+\--
+
+Metoda `create` bude vytvářet komponentu `UserTable` s následující definicí:
+
+/--php
+namespace App\Components;
+
+class UserTable extends Control
+{
+	private $userManager;
+
+	public function __construct(UserManager $userManager)
+	{
+		$this->userManager = $userManager;
+	}
+}
+\--
+
+Továrnu zaregistrujeme v `config.neon`:
+
+/--code neon
+services:
+	- App\Components\IUserTableFactory
+\--
+
+Nette zkontroluje, zda se jedná o rozhraní a pokud ano, tak vygeneruje příslušnou implementaci továrny. Uvedený zápis by bylo možné také rozepsat takto:
+
+/--code neon
+services:
+	userTableFactory:
+		implement: App\Components\IUserTableFactory
+\--
+
+Při zápisu tímto způsobem je možné pro komponentu definovat argumenty pomocí klíče `arguments` a doplňující konfiguraci pomocí `setup` stejně, jako u ostatních služeb.
+
+V presenteru pak bude stačit získat příslušnou závislost a zavolat metodu `create`:
+
+/--php
+class UserPresenter extends Nette\Application\UI\Presenter
+{
+	/** @var \App\Components\IUserTableFactory @inject */
+	public $userTableFactory;
+
+	protected function createComponentUserTable()
+	{
+		return $this->userTableFactory->create();
+	}
+}
+\--
+
+Vytvořené komponentě budou automaticky konstruktorem předány její závislosti.

--- a/en/di-usage.texy
+++ b/en/di-usage.texy
@@ -1,0 +1,438 @@
+Getting Dependencies
+********************
+
+/--div .[perex]
+There are several possibilities of injecting dependencies to presenters, components and services. This article discusses:
+
+* dependency injection in general, not limited to the dependencies in Nette "DI Container":[dependency-injection], and
+* practical examples and recommendations for presenters, components and services.
+\--
+
+
+How To Get Dependencies?
+========================
+
+Dependencies can be injected to the application classes in one of the following ways:
+
+* through the class constructor,
+* via setter or a member variable,
+* through the `inject*` method,
+* using the `@inject` annotation on a `public` member variable.
+
+First two ways can be used in all object-oriented programming languages, last two are available in Nette Framework. Let's walk through all these ways and then show their application in practical examples.
+
+
+Constructor Passing
+-------------------
+
+All dependencies are passed when the object is being created. The dependency is declared as a constructor parameter and its type is given in the Type Hint:
+
+/--php
+class MyService
+{
+	/** @var AnotherService */
+	private $anotherService
+
+	public function __construct(AnotherService $service) {
+		$this->anotherService = $service;
+	}
+}
+\--
+
+THe `MyService` class declares that an instance of `AnotherService` class must be passed during the object creation. This declaration is suitable for all mandatory dependencies, which are required for the functioning of the class. The class could not be instantiated without these dependencies.
+
+
+Passing by Setter or a Public Variable
+--------------------------------------
+
+These dependencies are passed after the object has been created. Take a look at the example of passing dependency by a setter method. The type of the dependency is given in the Type Hint:
+
+/--php
+class MyService
+{
+	/** @var AnotherService */
+	private $anotherService
+		
+	public function setAnotherService(AnotherService $service)
+	{
+		$this->anotherService = $service;
+	}
+}
+\--
+
+These dependencies can be passed only after the object has been created. This method is suitable only for non-mandatory dependencies, because there is no guarantee that the dependencies will be passed to the object.
+
+Passing by a public variable works in a very similar way:
+
+/--php
+class MyService
+{
+	/** @var AnotherService */
+	public $anotherService;
+}
+\--
+
+However, this method is not recommended, because the variable must be declared as public and there is no way how you can ensure that the passed object will be of the given type. We also lose the ability to handle the assigned dependency in our code and we violate the principles of encapsulation.
+
+
+Passing by an `inject*` Method
+---------------------------
+
+This method is specific for the DI Container in Nette Framework. It is a special case of setter method which starts with an `inject*` prefix.
+
+/--php
+class MyService
+{
+	/** @var AnotherService */
+	public $anotherService;
+	
+	public function injectAnotherService(AnotherService $service)
+	{
+		$this->anotherService = $service;
+	}
+}
+\--
+
+The class can contain multiple `inject*` methods, each with multiple parameters and a unique name.
+
+Nette is able to find these methods in presenters and automatically call them with proper parameters. This behaviour could be also enabled in services in configuration file. This will be explained later.
+
+`@inject` Annotations
+-----------------
+
+Second method specific for Nette Framework. It is a special case of passing by a public variable. The variable is marked by an `@inject` annotation in a docblock comment:
+
+/--php
+class MyService
+{
+	/** @inject @var \App\AnotherService */
+	public $anotherService;
+}
+\--
+
+Nette Framework can also scan the presenter for these variables and automatically inject these dependencies. The variable type in `@var` annotation must be given by its fully qualified name, including namespace. Aliases defined in `use` directives can be used since version 2.2.
+
+This approach has the same drawbacks as ordinary passing by a public variable - we cannot enforce the type of passed dependency.
+
+However, the code is very simple and short, which can be an advantage in some cases.
+
+Which Way Should I Choose?
+==========================
+
+Constructor passing and passing optional dependencies by setters are available for all instantiated classes. The following two techniques, passing dependencies by `inject*` methods and by public variables marked by the `@inject` annotation, are less clean techniques and are available only in presenters and services in DI container with explicit configuration. We use them only in a few specific cases.
+
+The one thing that all these methods have in common, is that [auto-wiring | configuring#auto-wiring] is only available for objects created by Nette DI Container or one of the factories in Nette. When we create the object by calling `new`, we have to pass the dependencies manually.
+
+Lets have a look at the examples and preferred method of dependency injection.
+
+Presenters
+----------
+
+Presenters in Nette Framework is created by the `PresenterFactory`. This factory also automatically injects dependencies declared:
+
+1) in a constructor,
+2) using the `inject*` methods,
+3) by public properties with the `@inject` annotation.
+
+The following presenter shows all three ways of dependency passing:
+
+/--php
+class MyPresenter extends Nette\Application\UI\Presenter
+{	
+	// 1) Constructor passing:
+	private $service1;
+	
+	public function __construct(Service1 $service)
+	{
+		$this->service1 = $service;
+	}
+	
+	// 2) Using the inject* method:
+	private $service2;
+	
+	public function injectService2(Service2 $service)
+	{
+		$this->service2 = $service;
+	}
+	
+	// 3) Public variable with the @inject annotation:
+	/** @inject @var \App\Service3 */
+	public $service3;
+}
+\--
+
+The preferred way of passing dependencies for presenters is using the `@inject` annotation, because it is simple, it does not complicate the code, and the presenter creation and dependency injection is automatically handled by Nette.
+
+Pokud potřebujete přesně definovat kontrakt presenteru (může být vhodné například pro testování), použijte metody `inject*`.
+
+If you need to explicitly specify the contract of presenter (which could be very useful for testing), use the `inject*` method.
+
+Passing dependencies through the constructor is not recommended, since it complicates the constructor signature when using the presenter inheritance: you have to get and pass dependencies to all parent presenter classes.
+
+Components
+----------
+
+Components are usually instantiated directly in the code of presenter, or through the application-specific factories. In these cases, Nette cannot automatically inject the dependencies and you cannot use `inject*` methods or variables with the `@inject` annotations.
+
+Lets consider we have the following component:
+
+/--php
+class MyControl extends Nette\Application\UI\Control
+{
+	// 1) Constructor passing:
+	private $service1;
+	
+	public function __construct(Service1 $service)
+	{
+		parent::__construct();
+		$this->service1 = $service;
+	}
+	
+	// 2) Optional dependency injected by setter:
+	private $service2;
+	
+	public function setService2(Service2 $service)
+	{
+		$this->service2 = $service;
+	}
+}
+\--
+
+The component could be used in the presenter in the following way:
+
+/--php
+class MyPresenter extends Nette\Application\UI\Presenter
+{
+	/** @inject @var \App\Service1 */
+	private $service1;
+	/** @inject @var \App\Service2 */
+	private $service2;
+	
+	protected function createCompoonentMyControl()
+	{
+		$control = new MyControl($this->service1);
+		$control->setService2($this->service2);
+		return $control;
+	}
+}
+\--
+
+Because dependencies are not automatically injected by the DI container, we have to obtain all the required dependencies also in the class, that creates our component - the presenter in our example. If we create the component in another component, the component dependencies will be added to the dependencies of the parent component:
+
+/--php
+class MySecondControl extends Nette\Application\UI\Control
+{
+	// Dependencies for MySecondControl:
+	private $service3;
+	// Dependencies for the child MyControl:
+	private $service1;
+	private $service2;
+	
+	public function __construct(Service1 $service1, Service2 $service2,
+	                            Service3 $service3)
+	{
+		public::__construct();
+		// assign dependencies to members $service1, $service2, $service3
+	}
+	
+	protected function createCompoonentMyControl()
+	{
+		$control = new MyControl($this->service1);
+		$control->setService2($this->service2);
+		return $control;
+	}
+}
+\--
+
+Because we usually instantiate the components by hand, the preferred way of dependency injection depends on whether the dependency is mandatory or optional. Constructor should be used for mandatory dependencies and setter for optional ones.
+
+.[caution]
+If we use the constructor for dependency passing, we must not forget to call the constructor from the parent class: `parent::__construct()`!
+
+Services
+--------
+
+Services are registered in the DI container and dependencies are therefore automatically passed. We can declare dependencies only in constructor, unless we provide additional configuration:
+
+/--code neon
+services:
+	service1: App\Service1
+\--
+
+All dependencies declared in the constructor of this service will be automatically passed:
+
+/--php
+class Service1
+{
+	private $anotherService;
+	
+	public function __construct(AnotherService $service)
+	{
+		$this->anotherService = $service;
+	}
+}
+\--
+
+Constructor passing is the preferred way of dependency injection for services.
+
+If we want to pass dependencies by the setter, we can add the `setup` section to the service definition:
+
+/--code neon
+services:
+	service2:
+		class: App\Service2
+		setup:
+			- setAnotherService
+\--
+
+Class of the service:
+
+/--php
+class Service2
+{
+	private $anotherService;
+	
+	public function setAnotherService(AnotherService $service)
+	{
+		$this->anotherService = $service;
+	}
+}
+\--
+
+We can also add the `inject: yes` directive. This directive will enable automatic call of `inject*` methods and passing dependencies to public variables with `@inject` annotations:
+
+/--code neon
+services:
+	service3:
+		class: App\Service3
+		inject: yes
+\--
+
+Dependency `Service1` will be passed by calling the `inject*` method, dependency `Service2` will be assigned to the `$service2` variable:
+
+/--php
+class Service3
+{
+	// 1) inject* method:
+	private $service1;
+	
+	public function injectService1(Service1 $service)
+	{
+		$this->service1 = $service1;
+	}
+	
+	// 2) Assign to the variable with the @inject annotation:
+	/** @inject @var \App\Service2 */
+	public $service2;
+}
+\--
+
+
+Other Possibilities
+===================
+
+There are also a few other possibilities, how we can change the configuration and dependency injection for presenters and components.
+
+Presenter as a Service
+---------------------
+
+Beginning with the Nette 2.1, you can register the presenter as a service to the configuration file. It will be created as any other service in the DI container. You can pass any parameters that could not be auto-wired (strings, numbers, ...), and add setter calls.
+
+All `inject*` methods will be called automatically and all dependencies will be automatically assigned to the public variables with the `@inject` annotation. You do not have to add the `inject: yes` directive.
+
+The presenter definition in the configuration file could look as following:
+
+/--code neon
+services:
+	- App\Presenters\ImagePresenter("%wwwDir%/media")
+\--
+
+/--php
+class ImagePresenter extends Nette\Application\UI\Presenter
+{
+	private $imageDir;
+	private $optimizer;
+
+	public function __construct($imageDir, ImageOptimizer $optimizer)
+	{
+		$this->imageDir = $imageDir;
+		$this->optimizer = $optimizer;
+	}
+}
+\--
+
+The string from the configuration will be passed as the first parameter of the constructor, the remaining parameters will be auto-wired.
+
+However, you have to be careful when designing presenters. All application logic should not be in services, not in presenters. The need of additional presenter configuration is often a sign of a bad decomposition of the problem.
+
+
+Component Factory
+-----------------
+
+Like presenters, components can be also registered in the configuration file. However, the presenter is usually created only once during the handling of a single request, while components can be instantiated at multiple locations. Therefore we have to register a component factory instead of a service.
+
+Beginning with Nette 2.1, we can use factories generated from an interface. The interface must declare the returning type in the `@return` annotation of the method. Nette will generate a proper implementation of the interface.
+
+The interface must have exactly one method named `create`. Our component factory interface could be declared in the following way:
+
+/--php
+namespace App\Components;
+
+interface IUserTableFactory
+{
+	/**
+	 * @return UserTable
+	 */
+	public function create();
+}
+\--
+
+The `create` method will instantiate an `UserTable` component with the following definition:
+
+/--php
+namespace App\Components;
+
+class UserTable extends Control
+{
+	private $userManager;
+
+	public function __construct(UserManager $userManager)
+	{
+		$this->userManager = $userManager;
+	}
+}
+\--
+
+The factory will be registered in the `config.neon` file:
+
+/--code neon
+services:
+	- App\Components\IUserTableFactory
+\--
+
+Nette will check if the declared service is an interface. If yes, it will also generate the corresponding implementation of the factory. The definition can be also written in a more verbose form:
+
+/--code neon
+services:
+	userTableFactory:
+		implement: App\Components\IUserTableFactory
+\--
+
+This full definition allows us to declare additional configuration of the component using the `arguments` and `setup` sections, similarly as for all other services.
+
+In the presenter, we only have to obtain the factory instance and call the `create` method:
+
+/--php
+class UserPresenter extends Nette\Application\UI\Presenter
+{
+	/** @var \App\Components\IUserTableFactory @inject */
+	public $userTableFactory;
+
+	protected function createComponentUserTable()
+	{
+		return $this->userTableFactory->create();
+	}
+}
+\--
+
+Constructor dependencies will be automatically passed to the created control.


### PR DESCRIPTION
Draft of a new chapter of documentation that discusses possibilities of getting dependencies into application classes and provides a list of examples on various types of injections for presenters, components and services.

The page will be further extended to contain some specific cases, like presenters or component factories registered in the DI Container.

This draft is currently only in Czech language, it will by translated after corrections and expansion.

Any feedback is welcome.
