### PR TITLE
Better wording, $form['element']->addError() and $defaultMessages

### DIFF
--- a/en/forms.texy
+++ b/en/forms.texy
@@ -393,7 +393,7 @@ $form->addText('number', 'Number:')
 Custom errors
 -------------
 
-We often find out that user's input is invalid upon already working with validated form, for example when inserting a new database row and stumble upon a duplicate key. In that case, we can add the error manually with `addError()` method. It can be called either on a specific input or a form itself:
+We often find that user's input is wrong even though each of the form's elements is technically valid. For example stumbling upon a duplicate key when inserting a new database row. Or invalid login credentials. In that case, we can add the error manually with `addError()` method. It can be called either on a specific input or a form itself:
 
 /--php
 try {
@@ -404,6 +404,20 @@ try {
 } catch (Nette\Security\AuthenticationException $e) {
 	$form->addError($e->getMessage());
 }
+\--
+
+It's recommended to link the error directly to a form element because then the error will be displayed next to it, when using default renderer.
+
+/--php
+$form['date']->addError("We apologize but this date has been already taken.");
+\--
+
+
+Global default messages
+-----------------------
+To globally change validation error messages, modify static array Nette\Forms\Rules::$defaultMessages.
+/--php
+Nette\Forms\Rules::$defaultMessages[Form::FILLED] = "All fields are obligatory.";
 \--
 
 


### PR DESCRIPTION
When looking for where to put a reference for $defaultMessages, I found that the wording in Custom errors isn't very good. So I did my best to rephrase it better. I also added 2.1 method for adding errors to form components.
