### PR TITLE
More tags in a call to $cache->clean()

### DIFF
--- a/en/caching.texy
+++ b/en/caching.texy
@@ -240,6 +240,8 @@ $cache->clean(array(
 What we have achieved? That the HTML cache will invalidate automatically. Whenever someone changes the article with ID of 10, it will force the `article/10`
 tag to invalidate and the tagged HTML page in cache is cleared. The same will happen when someone inserts a new comment below the article.
 
+You can invalidate cached items that match at least one of given tags by passing more tags to `$cache->clean`. You cannot however, invalidate items that match all given tags. In other words, the relationship among tags passed to `$cache->clean()` is OR, not AND.
+
 Similar to tags, you can control expiration by priority:
 
 /--php


### PR DESCRIPTION
Explains that the relationship is OR, not AND.
