### PR TITLE
Updated best practices for passing dependencies to presenters

### DIFF
--- a/cs/di-usage.texy
+++ b/cs/di-usage.texy
@@ -162,11 +162,11 @@ class MyPresenter extends Nette\Application\UI\Presenter
 }
 \--
 
-Preferovaný způsob předávání závislostí je pomocí anotace `@inject`, neboť nekomplikuje kód a Nette se o předání správné závislosti stará automaticky.
+Preferovaný způsob předávání závislostí je pomocí konstruktoru, nebo v případě rodičovských presenterů pomocí metody `inject*`. Použitím metody `inject*` u rodičovských presenterů zachováme zapouzdření a zároveň si ponecháme konstruktor čistý pro potomky.
 
-Pokud potřebujete přesně definovat kontrakt presenteru (může být vhodné například pro testování), použijte metody `inject*`.
+U obou případů je také možné použít anotaci `@inject`, je třeba však mít na paměti, že dojde k porušení zapouzdření.
 
-Předávání pomocí konstruktoru je spíše nedoporučované, protože při dědění presenterů je nutné získávat závislosti i všech rodičovských presenterů a to komplikuje signaturu konstruktoru.
+Předávání pomocí konstruktoru je u rodičovských presenterů spíše nedoporučované, protože při dědění presenterů je nutné získávat závislosti i všech rodičovských presenterů a to komplikuje signaturu konstruktoru.
 
 Komponenty
 ----------

--- a/en/di-usage.texy
+++ b/en/di-usage.texy
@@ -161,13 +161,11 @@ class MyPresenter extends Nette\Application\UI\Presenter
 }
 \--
 
-The preferred way of passing dependencies for presenters is using the `@inject` annotation, because it is simple, it does not complicate the code, and the presenter creation and dependency injection is automatically handled by Nette.
+The preferred way of passing dependencies for presenters is using the constructor, or in case of parent presenters using the `inject*` method. The usage of `inject*` method in parent presenters allows us to preserve encapsulation and to keep the constructor clean for child presenters.
 
-Pokud potřebujete přesně definovat kontrakt presenteru (může být vhodné například pro testování), použijte metody `inject*`.
+We can also use `@inject` annotation for both cases, but we have to keep in mind that this breaks encapsulation.
 
-If you need to explicitly specify the contract of presenter (which could be very useful for testing), use the `inject*` method.
-
-Passing dependencies through the constructor is not recommended, since it complicates the constructor signature when using the presenter inheritance: you have to get and pass dependencies to all parent presenter classes.
+Passing dependencies to parent presenters through the constructor is not recommended, since it complicates the constructor signature when using the presenter inheritance: you have to get and pass dependencies to all parent presenter classes.
 
 Components
 ----------


### PR DESCRIPTION
I think it might be better if we stop recommending @inject annotation in presenters in favor of inject\* methods and constructor. Related discussion is [here](http://forum.nette.org/cs/17817-jak-dostat-do-basecontrol-sluzbu-aniz-by-se-ji-museli-potomci-zabyvat) (in czech).

Also this is my first pull request ever, so please, be gentle if I did something wrong :-)
