### PR TITLE
Custom authenticator - missing negation in the condition

### DIFF
--- a/cs/access-control.texy
+++ b/cs/access-control.texy
@@ -123,7 +123,7 @@ class MyAuthenticator extends Nette\Object implements NS\IAuthenticator
 			throw new NS\AuthenticationException('User not found.');
 		}
 
-		if (NS\Passwords::verify($password, $row->password)) {
+		if (!NS\Passwords::verify($password, $row->password)) {
 			throw new NS\AuthenticationException('Invalid password.');
 		}
 

--- a/en/access-control.texy
+++ b/en/access-control.texy
@@ -124,7 +124,7 @@ class MyAuthenticator extends Nette\Object implements NS\IAuthenticator
 			throw new NS\AuthenticationException('User not found.');
 		}
 
-		if (NS\Passwords::verify($password, $row->password)) {
+		if (!NS\Passwords::verify($password, $row->password)) {
 			throw new NS\AuthenticationException('Invalid password.');
 		}
 


### PR DESCRIPTION
The condition was written with mistake - it returned exception on
password match. I changed it in both locales.
