### PR TITLE
Update jak-predavat-id-pri-editaci-zaznamu.texy

### DIFF
--- a/pla/cs/jak-predavat-id-pri-editaci-zaznamu.texy
+++ b/pla/cs/jak-predavat-id-pri-editaci-zaznamu.texy
@@ -62,7 +62,7 @@ class RecordPresenter extends BasePresenter
 		}
 
 		$values = $form->getValues();
-		$this->model->records->update($this->record->id, $values);
+		$this->model->records->update($this->id, $values);
 
 		$this->flashMessage("Record updated!", "success");
 		$this->redirect("edit");


### PR DESCRIPTION
Jinak nedává použití persistentního parametru smysl. Při použití $this->record->id nemusí být id jako persistentní, vlastně nemusí být deklarováno vůbec.
