### PR TITLE
%line% must not be quoted for PhpStorm

### DIFF
--- a/pla/en/how-open-files-in-ide-from-debugger.texy
+++ b/pla/en/how-open-files-in-ide-from-debugger.texy
@@ -20,7 +20,7 @@ var editor = '"C:\\Program Files\\NetBeans 6.9.1\\bin\\netbeans.exe" "%file%:%li
 //~ var editor = '"C:\\Program Files\\NuSphere\\PhpED\\phped.exe" "%file%" --line=%line%';
 
 // PhpStorm
-//~ var editor = '"C:\\Program Files\\PhpStorm\\PhpStorm.exe" --line "%line%" "%file%"';
+//~ var editor = '"C:\\Program Files\\PhpStorm\\PhpStorm.exe" --line %line% "%file%"';
 
 // SciTE
 //~ var editor = '"C:\\Program Files\\SciTE\\scite.exe" "-open:%file%" -goto:%line%';


### PR DESCRIPTION
(actually tested on IntelliJ IDEA which shares the same platform)
