### PR TITLE
Update di-usage.texy

### DIFF
--- a/en/di-usage.texy
+++ b/en/di-usage.texy
@@ -31,15 +31,16 @@ All dependencies are passed when the object is being created. The dependency is 
 class MyService
 {
 	/** @var AnotherService */
-	private $anotherService
+	private $anotherService;
 
-	public function __construct(AnotherService $service) {
+	public function __construct(AnotherService $service)
+	{
 		$this->anotherService = $service;
 	}
 }
 \--
 
-THe `MyService` class declares that an instance of `AnotherService` class must be passed during the object creation. This declaration is suitable for all mandatory dependencies, which are required for the functioning of the class. The class could not be instantiated without these dependencies.
+The `MyService` class declares that an instance of `AnotherService` class must be passed during the object creation. This declaration is suitable for all mandatory dependencies, which are required for the functioning of the class. The class could not be instantiated without these dependencies.
 
 
 Passing by Setter or a Public Variable
@@ -51,7 +52,7 @@ These dependencies are passed after the object has been created. Take a look at 
 class MyService
 {
 	/** @var AnotherService */
-	private $anotherService
+	private $anotherService;
 
 	public function setAnotherService(AnotherService $service)
 	{
@@ -84,7 +85,7 @@ This method is specific for the DI Container in Nette Framework. It is a special
 class MyService
 {
 	/** @var AnotherService */
-	public $anotherService;
+	private $anotherService;
 
 	public function injectAnotherService(AnotherService $service)
 	{
@@ -202,11 +203,12 @@ The component could be used in the presenter in the following way:
 class MyPresenter extends Nette\Application\UI\Presenter
 {
 	/** @inject @var \App\Service1 */
-	private $service1;
+	public $service1;
+	
 	/** @inject @var \App\Service2 */
-	private $service2;
+	public $service2;
 
-	protected function createCompoonentMyControl()
+	protected function createComponentMyControl()
 	{
 		$control = new MyControl($this->service1);
 		$control->setService2($this->service2);
@@ -222,18 +224,18 @@ class MySecondControl extends Nette\Application\UI\Control
 {
 	// Dependencies for MySecondControl:
 	private $service3;
+	
 	// Dependencies for the child MyControl:
 	private $service1;
 	private $service2;
 
-	public function __construct(Service1 $service1, Service2 $service2,
-	                            Service3 $service3)
+	public function __construct(Service1 $service1, Service2 $service2, Service3 $service3)
 	{
 		parent::__construct();
 		// assign dependencies to members $service1, $service2, $service3
 	}
 
-	protected function createCompoonentMyControl()
+	protected function createComponentMyControl()
 	{
 		$control = new MyControl($this->service1);
 		$control->setService2($this->service2);
@@ -260,6 +262,8 @@ services:
 All dependencies declared in the constructor of this service will be automatically passed:
 
 /--php
+namespace App;
+
 class Service1
 {
 	private $anotherService;
@@ -286,6 +290,8 @@ services:
 Class of the service:
 
 /--php
+namespace App;
+
 class Service2
 {
 	private $anotherService;
@@ -309,6 +315,8 @@ services:
 Dependency `Service1` will be passed by calling the `inject*` method, dependency `Service2` will be assigned to the `$service2` variable:
 
 /--php
+namespace App;
+
 class Service3
 {
 	// 1) inject* method:
@@ -332,9 +340,9 @@ Other Possibilities
 There are also a few other possibilities, how we can change the configuration and dependency injection for presenters and components.
 
 Presenter as a Service
----------------------
+----------------------
 
-Beginning with the Nette 2.1, you can register the presenter as a service to the configuration file. It will be created as any other service in the DI container. You can pass any parameters that could not be auto-wired (strings, numbers, ...), and add setter calls.
+Beginning with the Nette 2.1, you can register the presenter as a service to the configuration file. It will be created as any other service in the DI container. You can pass any parameters that could not be auto-wired (strings, numbers, etc.), and add setter calls.
 
 All `inject*` methods will be called automatically and all dependencies will be automatically assigned to the public variables with the `@inject` annotation. You do not have to add the `inject: yes` directive.
 
@@ -361,7 +369,8 @@ class ImagePresenter extends Nette\Application\UI\Presenter
 
 The string from the configuration will be passed as the first parameter of the constructor, the remaining parameters will be auto-wired.
 
-However, you have to be careful when designing presenters. All application logic should be in services, not in presenters. The need of additional presenter configuration is often a sign of a bad decomposition of the problem.
+.[caution]
+However, you have to be careful when designing presenters. All application logic should be in services, not in presenters. The need of additional presenter configuration is often a sign of a bad decomposition of the challenge.
 
 
 Component Factory


### PR DESCRIPTION
Correct several typos in code examples and also in text (formulation, typos etc.)

Done changes?
- add missing semicolons
- add namespace declaration statements
- add caution block under "Other possibilities" title
- correct wrong access modifiers on properties/methods
- correct few typos in text
