### PR TITLE
Database [wip]

### DIFF
--- a/cs/database-activerow.texy
+++ b/cs/database-activerow.texy
@@ -3,6 +3,7 @@ Database: ActiveRow
 
 Každý řádek, který vrátí [Selection | api:Nette\Database\Table\Selection], je reprezentován instancí [ActiveRow | api:Nette\Database\Table\ActiveRow]. Tato třída poskytuje standardní interface pro přístup k vybraným sloupcům. Data můžeme číst jako členské proměnné nebo použít přístup přes klíče pole. Pokud sloupec neexistuje, je vyhozena výjimka [MemberAccessException | api:Nette\MemberAccessException]. Pomocí standardní konstrukce `isset` lze ověřit, zda má sloupec nastavenou neprázdnou hodnotu.
 
+
 /--code php
 echo $book->id;
 echo $book['title'];
@@ -11,7 +12,7 @@ isset($book->id);
 isset($book['title']);
 \--
 
-Pozor, `isset` vrátí FALSE, i když byl sloupec dotazem vybrán, ale má hodnotu `NULL`.
+Pozor, `isset` vrátí `FALSE`, i když byl sloupec dotazem vybrán, ale má hodnotu `NULL`.
 
 
 Vztahy

--- a/cs/database-activerow.texy
+++ b/cs/database-activerow.texy
@@ -1,7 +1,7 @@
 Database: ActiveRow
 *******************
 
-Každý řádek, který vrátí [Selection | api:Nette\Database\Table\Selection] je reprezentován instancí [ActiveRow | api:Nette\Database\Table\ActiveRow]. Tato třída poskytuje standardní interface pro přístup k vybraným sloupcům. Data může číst jako členské proměnné nebo použít přístup přes klíče pole. Pokud sloupec neexistuje, je vyhozena výjimka [MemberAccessException | api:Nette\MemberAccessException]. Pomocí standardní konstrukce `isset` lze ověřit, zda má sloupec nastavenou neprázdnou hodnotu.
+Každý řádek, který vrátí [Selection | api:Nette\Database\Table\Selection], je reprezentován instancí [ActiveRow | api:Nette\Database\Table\ActiveRow]. Tato třída poskytuje standardní interface pro přístup k vybraným sloupcům. Data můžeme číst jako členské proměnné nebo použít přístup přes klíče pole. Pokud sloupec neexistuje, je vyhozena výjimka [MemberAccessException | api:Nette\MemberAccessException]. Pomocí standardní konstrukce `isset` lze ověřit, zda má sloupec nastavenou neprázdnou hodnotu.
 
 /--code php
 echo $book->id;
@@ -11,7 +11,7 @@ isset($book->id);
 isset($book['title']);
 \--
 
-Pozor, `isset` vrátí FALSE, i když byl sloupec dotazem vybrán, ale má hodnotu NULL.
+Pozor, `isset` vrátí FALSE, i když byl sloupec dotazem vybrán, ale má hodnotu `NULL`.
 
 
 Vztahy
@@ -20,18 +20,18 @@ Vztahy
 Hlavním principem Nette\Database\Table je oddělené načítání dat z různých tabulek. Toto chování je zajišťováno samotnou Nette\Database, příbuzná data jsou z databáze vybrána pro všechny řádky najednou. Máme dva hlavní druhy vztahů: "has one" a "has many".
 
 .[note]
-Budeme používat DiscoveredConventions, která načte vztahy mezi tabulkami přímo z databáze.
+Budeme používat `DiscoveredConventions`, která načte vztahy mezi tabulkami přímo z databáze.
 
 Relace Has one
 --------------
-Relace has one je velmi běžná. Kniha *má jednoho* autora. Kniha *má jednoho* překladatele. Řádek, který je ve vztahu has one získáme pomocí metody [ref() | api:Nette\Database\Table\ActiveRow::ref()]. Ref() přijímá dva argumenty: jméno cílové tabulky a název spojovacího sloupce. Viz příklad:
+Relace has one je velmi běžná. Kniha *má jednoho* autora. Kniha *má jednoho* překladatele. Řádek, který je ve vztahu has one získáme pomocí metody [ref() | api:Nette\Database\Table\ActiveRow::ref()]. `ref()` přijímá dva argumenty: jméno cílové tabulky a název spojovacího sloupce. Viz příklad:
 
 /--code php
 $book = $context->table('book')->get(1);
 $book->ref('author', 'author_id');
 \--
 
-V příkladu výše vybíráme souvisejícího autora z tabulky `author`. Primární klíč tabulky `author` je hledán podle sloupce `book.author_id`. Metoda ref() vrací instanci ActiveRow nebo NULL, pokud hledaný záznam neexistuje. Vrácený řádek je instance ActiveRow, takže s ním můžeme pracovat stejně jako se záznamem knihy.
+V příkladu výše vybíráme souvisejícího autora z tabulky `author`. Primární klíč tabulky `author` je hledán podle sloupce `book.author_id`. Metoda `ref()` vrací instanci `ActiveRow` nebo `NULL`, pokud hledaný záznam neexistuje. Vrácený řádek je instance `ActiveRow`, takže s ním můžeme pracovat stejně jako se záznamem knihy.
 
 /--code php
 $author = $book->ref('author', 'author_id');
@@ -50,7 +50,7 @@ $book->ref('author', 'translator_id')->name
 
 Tento přístup je funkční, ale pořád trochu zbytečně těžkopádný, nemyslíte? Databáze už obsahuje definice cizích klíčů, tak proč je nepoužít automaticky. Pojďme to vyzkoušet.
 
-Pokud přistoupíme k členské proměnné, která neexistuje, ActiveRow se pokusí použít jméno této proměnné pro relaci "has one". Čtení této proměnné je stejné jako volání metody ref() pouze s jedním parametrem. Tomuto parametru budeme říkat **klíč**. Tento klíč bude použit pro vyhledání cizího klíče v tabulce. Předaný klíč je porovnán se sloupci, a pokud odpovídá pravidlům, je cizí klíč na daném sloupci použit pro čtení dat z příbuzné tabulky. Viz příklad:
+Pokud přistoupíme k členské proměnné, která neexistuje, ActiveRow se pokusí použít jméno této proměnné pro relaci "has one". Čtení této proměnné je stejné jako volání metody `ref()` pouze s jedním parametrem. Tomuto parametru budeme říkat **klíč**. Tento klíč bude použit pro vyhledání cizího klíče v tabulce. Předaný klíč je porovnán se sloupci, a pokud odpovídá pravidlům, je cizí klíč na daném sloupci použit pro čtení dat z příbuzné tabulky. Viz příklad:
 
 /--code php
 $book->author->name;
@@ -58,7 +58,7 @@ $book->author->name;
 $book->ref('author')->name;
 \--
 
-Instance ActiveRow nemá žádný sloupec author. Všechny sloupce tabulky book jsou prohledány na shodu s *klíčem*. Shoda v tomto případě znamená, že jméno sloupce musí obsahovat klíč. V příkladu výše sloupec `author_id` obsahuje řetězec "author" a tedy odpovídá klíči "author". Pokud chceme přistoupit k záznamu překladatele, obdobným způsobem použijeme klíč "translator",  protože bude odpovídat sloupci `translator_id`. Více o logice párování klíčů si můžete přečíst v kapitole [Joining expressions | database-selection#joining-key].
+Instance ActiveRow nemá žádný sloupec `author`. Všechny sloupce tabulky `book` jsou prohledány na shodu s *klíčem*. Shoda v tomto případě znamená, že jméno sloupce musí obsahovat klíč. V příkladu výše sloupec `author_id` obsahuje řetězec "author" a tedy odpovídá klíči "author". Pokud chceme přistoupit k záznamu překladatele, obdobným způsobem použijeme klíč "translator", protože bude odpovídat sloupci `translator_id`. Více o logice párování klíčů si můžete přečíst v kapitole [Joining expressions | database-selection#joining-key].
 
 /--code php
 echo $book->title . ": ";
@@ -108,7 +108,7 @@ foreach ($author->related('book.translator_id') as $book) {
 }
 \--
 
-Metoda [related() | api:Nette\Database\Table\ActiveRow::related()] přijímá popis spojení jako dva argumenty, nebo jako jeden argument spojený tečkou. První argument je cílová tabulka, druhý je sloupec.
+Metoda `related()` přijímá popis spojení jako dva argumenty, nebo jako jeden argument spojený tečkou. První argument je cílová tabulka, druhý je sloupec.
 /--code php
 $author->related('book.translator_id');
 // je stejné jako
@@ -117,7 +117,7 @@ $author->related('book', 'translator_id');
 
 Můžeme použít heuristiku Nette\Database založenou na cizích klíčích a použít pouze **klíč**. Klíč bude porovnán s cizími klíči, které odkazují do aktuální tabulky (tabulka `author`). Pokud je nalezena shoda, Nette\Database použije tento cizí klíč, v opačném případě vyhodí výjimku [Nette\InvalidArgumentException | api:Nette\InvalidArgumentException] nebo [AmbiguousReferenceKeyException | api:Nette\Database\Conventions\AmbiguousReferenceKeyException]. Více o logice párování klíčů si můžete přečíst v kapitole [Joining expressions | database-selection#joining-key].
 
-Metodu related může samozřejmě volat na všechny získané autory a Nette\Database načte všechny odpovídající knihy najednou.
+Metodu `related()` může samozřejmě volat na všechny získané autory a Nette\Database načte všechny odpovídající knihy najednou.
 
 /--code php
 $authors = $context->table('author');

--- a/cs/database-selection.texy
+++ b/cs/database-selection.texy
@@ -5,7 +5,7 @@ Database: Selection
 
 Filtrování
 ----------
-Pojďme se podívat na základní API Selection. Jednoduché podmínky můžeme vytvořit zavoláním metody [where() |api:Nette\Database\Table\Selection::where()]. Otazníky v dotazu budou nahrazeny obsahem proměnných.
+Pojďme se podívat na základní API třídy Selection. Jednoduché podmínky můžeme vytvořit zavoláním metody [where() |api:Nette\Database\Table\Selection::where()]. Otazníky v dotazu budou nahrazeny obsahem proměnných.
 
 /--code php
 $selection->where('name = ?', $name);
@@ -81,7 +81,7 @@ $selection->group('author.id')
           ->having('COUNT(:book.id) > 3');
 \--
 
-Možná jste si všimli, že spojovací výraz odkazuje na book, ale není jasné, jestli spojujeme přes `author_id` nebo `translator_id`. Ve výše uvedeném příkladu Selection spojuje přes sloupec `author_id`, protože byla nalezena shoda se jménem zdrojové tabulky - tabulky `author`. Pokud by neexistovala shoda a existovalo více možností, Nette vyhodí výjimku [AmbiguousReferenceKeyException |api:Nette\Database\Conventions\AmbiguousReferenceKeyException].
+Možná jste si všimli, že spojovací výraz odkazuje na `book`, ale není jasné, jestli spojujeme přes `author_id` nebo `translator_id`. Ve výše uvedeném příkladu Selection spojuje přes sloupec `author_id`, protože byla nalezena shoda se jménem zdrojové tabulky - tabulky `author`. Pokud by neexistovala shoda a existovalo více možností, Nette vyhodí výjimku [AmbiguousReferenceKeyException |api:Nette\Database\Conventions\AmbiguousReferenceKeyException].
 
 Abychom mohli spojovat přes `translator_id`, stačí přidat volitelný "parametr" do spojovacího výrazu.
 
@@ -117,6 +117,13 @@ Podívejme se na různé možnosti filtrování a omezování výběru pomocí A
 | `$table->group($columns)` | Nastaví GROUP BY
 | `$table->having($having)` | Nastaví HAVING
 
+Nejen v metodě `where` můžeme použít parametry. Parametry jsou podporovány i v metodách `order, select, group a having`. A pokud do těchto metod dosazujeme hodnotu, je nutné parametry použít, aby Nette\Database správně dotaz escapovalo (viz [zapisování dotazů|database-table#zapisovani-dotazu]:
+
+/--code php
+$table->select('DATE_FORMAT(created, ?)', '%d.%m.%Y')
+\--
+
+
 Můžeme použít tzv. fluent interface, například `$table->where(...)->order(...)->limit(...)`. Více `where` podmínek je spojeno pomocí operátoru `AND`. Pro operátor `OR` musíme použít pouze jedno volání `where()`:
 
 /--code php
@@ -142,6 +149,9 @@ Můžeme vytvořit také agregaci výsledků:
 | `$table->max($column)` | Vrátí maximální hodnotu
 | `$table->sum($column)` | Vrátí součet všech hodnot
 | `$table->aggregation("GROUP_CONCAT($column)")` | Pro jakoukoliv jinou agregační funkci
+
+.[caution]
+Metoda `count()` bez uvedeného parametru vybere všechny záznamy a vrátí velikost pole, což je velmi neefektivní. Pokud potřebujete například spočítat počet řádků pro stránkování, vždy první argument uveďte.
 
 Čtení dat:
 

--- a/cs/database-table.texy
+++ b/cs/database-table.texy
@@ -11,7 +11,7 @@ Pojďme si vyzkoušet jednoduchý příklad. Potřebujeme z databáze vybrat kni
 
 Vrstva Database\Table poskytuje instanci [Selection |api:Nette\Database\Table\Selection], která reprezentuje výběr dat z *jedné* databázové tabulky. Tato instance umožňuje filtrování požadovaných dat a vrací je jako instance ActiveRow.
 
-Vytvoření Selection je jednoduché, stačí zavolat metodu [table() |api:Nette\Database\Context::table()] na objektu databázového připojení. Jak se k databázi připojíme je popsáno v kapitole [Nette\Database | database], pokud však používáme Nette\Database samostatně, je nutno tento objekt [vytvořit |#rucni-vytvoreni-database-context].
+Vytvoření Selection je jednoduché, stačí zavolat metodu [table() |api:Nette\Database\Context::table()] na objektu databázového připojení. Jak se [k databázi připojíme |database#Vytvoření pomocí aplikační konfigurace] je popsáno v kapitole [Nette\Database | database], pokud však používáme Nette\Database samostatně, je nutno tento objekt [vytvořit |#rucni-vytvoreni-database-context].
 
 /--code php
 $selection = $context->table('book'); // jméno tabulky je "book"
@@ -121,7 +121,7 @@ Pokud ale používáme Nette\Database samostatně a chceme využívat vrstvu Tab
 
 /--code php
 //$storage obsahuje implementaci Nette\Caching\IStorage, napr.:
-//$storage = new Nette\Caching\FileStorage('tempDirectory');
+//$storage = new Nette\Caching\FileStorage($tempDir);
 
 $connection = new Nette\Database\Connection($dsn, $user, $password);
 

--- a/cs/database-table.texy
+++ b/cs/database-table.texy
@@ -11,13 +11,13 @@ Pojďme si vyzkoušet jednoduchý příklad. Potřebujeme z databáze vybrat kni
 
 Vrstva Database\Table poskytuje instanci [Selection |api:Nette\Database\Table\Selection], která reprezentuje výběr dat z *jedné* databázové tabulky. Tato instance umožňuje filtrování požadovaných dat a vrací je jako instance ActiveRow.
 
-Vytvoření Selection je jednoduché, stačí zavolat metodu [table() |api:Nette\Database\Context::table()] na objektu databázového připojení. Jak se k databázi připojíme je popsáno v kapitole [Nette\Database | database].
+Vytvoření Selection je jednoduché, stačí zavolat metodu [table() |api:Nette\Database\Context::table()] na objektu databázového připojení. Jak se k databázi připojíme je popsáno v kapitole [Nette\Database | database], pokud však používáme Nette\Database samostatně, je nutno tento objekt [vytvořit |#rucni-vytvoreni-database-context].
 
 /--code php
 $selection = $context->table('book'); // jméno tabulky je "book"
 \--
 
-Selection implementuje interface [Traversable |php:Traversable]: nad instancí můžeme jednoduše iterovat a vybrat tak všechny knihy. Řádky jsou vráceny jako instance Active Row a data z nich můžeme přímo číst.
+Selection implementuje interface [Traversable |php:Traversable]: nad instancí můžeme jednoduše iterovat a vybrat tak všechny knihy. Řádky jsou vráceny jako instance ActiveRow a data z nich můžeme přímo číst.
 
 /--code php
 $books = $context->table('book');
@@ -80,6 +80,54 @@ SELECT `id`, `title`, `author_id` FROM `book`
 SELECT `id`, `name` FROM `author` WHERE (`author`.`id` IN (11, 12))
 SELECT `book_id`, `tag_id` FROM `book_tag` WHERE (`book_tag`.`book_id` IN (1, 4, 2, 3))
 SELECT `id`, `name` FROM `tag` WHERE (`tag`.`id` IN (21, 22, 23))
+\--
+
+Zapisování dotazů
+-----------------
+
+Database\Table umí chytře escapovat parametry a identifikátory. Pro správnou funkčnost je ale nutno dodržovat několik pravidel:
+
+- klíčová slova, názvy funkcí, procedur apod. psát velkými písmeny
+- názvy sloupečků a tabulek psát malými písmeny
+- hodnoty dosazovat přes parametry
+
+/--code php
+//SPATNE!:
+//->where("name like ?", "John"); //vygeneruje: `name` `like` ?
+//spravne:
+->where("name LIKE ?", "John");
+
+//SPATNE!:
+//->where("KEY = ?", $value); //KEY je klíčové slovo
+//spravne:
+->where("key = ?", $value); //vygeneruje: `key` = ?
+
+//SPATNE!:
+//->where("name = " . $name); //sql injection!
+//spravne:
+->where("name = ?", $name);
+\--
+
+.[warning]
+Špatné použití může vést k bezpečnostním dírám v aplikaci.
+
+
+Ruční vytvoření Database\Context
+--------------------------------
+
+Pokud jsme si vytvořili databázové spojení pomocí aplikační konfigurace, nemusíme se o nic starat. Vytvořila se nám totiž i služba typu `Nette\Database\Context`, kterou si můžeme předat pomocí DI.
+
+Pokud ale používáme Nette\Database samostatně a chceme využívat vrstvu Table, musíme instanci Database\Context vytvořit ručně.
+
+/--code php
+//$storage obsahuje implementaci Nette\Caching\IStorage, napr.:
+//$storage = new Nette\Caching\FileStorage('tempDirectory');
+
+$connection = new Nette\Database\Connection($dsn, $user, $password);
+
+$structure = new Nette\Database\Structure($connection, $storage);
+$conventions = new Nette\Database\Conventions\DiscoveredConventions($structure);
+$context = new Nette\Database\Context($connection, $structure, $conventions, $storage);
 \--
 
 {{toc: title}}

--- a/cs/database.texy
+++ b/cs/database.texy
@@ -15,58 +15,33 @@ Třída [api:Nette\Database\Connection] tvoří obálku nad [php:PDO] a reprezen
 Vytvoření připojení
 ===================
 
-Pro vytvoření nového připojení k databázi stačí vytvořit novou instanci třídy [api:Nette\Database\Connection]:
+Pro vytvoření nového připojení k databázi stačí vytvořit novou instanci třídy [api:Nette\Database\Connection]. To provedeme buď [pomocí aplikační konfigurace|#vytvoreni-pomoci-aplikacni-konfigurace] nebo v případě, kdy používáme Nette\Database samostatně, následovně:
 
 /--php
 use Nette\Database\Connection;
 $connection = new Connection($dsn, $user, $password);
 \--
 
-Nette\Database si vytvoří vlastní vnitřní ovladač a nastaví své chování podle toho, jaký používáte databázový server. Nette podporuje následující databáze:
+Více informací v odstavci [#pokročilé nastavení spojení]
 
-|* Databázový server  |* DSN jméno  |* Podpora v Database |* Podpora v Database\Table
-| MySQL               | mysql       | ANO                 | ANO
-| PostgreSQL          | pgsql       | ANO                 | ANO
-| Sqlite 3            | sqlite      | ANO                 | ANO
-| Sqlite 2            | sqlite2     | ANO                 | -
-| Oracle              | oci         | ANO                 | -
-| MS SQL (PDO_SQLSRV) | sqlsrv      | ANO                 | ANO
-| MS SQL (PDO_DBLIB)  | mssql       | ANO                 | -
-| ODBC                | odbc        | ANO                 | -
 
-Volitelný čtvrtý parametr konstruktoru [Connection |api:Nette\Database\Connection] umožňuje přidat dodatečné parametry. Tyto volby jsou předány jak konstruktoru PDO, tak vnitřnímu ovladači, mohou tedy obsahovat konfiguraci pro instanci PDO i pro instanci ovladače.
-
-Všechna připojení jsou v základu vytvořená "líně". To znamená, že připojení k databázi je navázáno až ve chvíli, kdy je poprvé potřeba, ne když je vytvořena instance `Connection`. Toto chování můžeme zakázat přidáním konfigurace `'lazy' => FALSE`.
-
-Ovladač databáze je zvolen podle použitého DSN jména. Můžeme ale poskytnout vlastní implementaci ovladače. To uděláme předáním jména ovladače jako hodnoty parametru `driverClass`.
-
-/--code php
-$connection = new Connection($dsn, $user, $password, array(
-	'lazy' => FALSE,
-	'driverClass' => 'App\JmenoVasiVlastniImplementaceOvladace'
-));
-\--
 
 Vytvoření pomocí aplikační konfigurace
 --------------------------------------
 
-Nejjednodušším způsobem, jak nastavit připojení k databázi, je v [aplikační konfiguraci |configuring], která umožňuje vytvoření více připojení a také usnadňuje přidání panelu databáze do Tracy debugger baru.
+Nejjednodušším způsobem, jak nastavit připojení k databázi, je v [aplikační konfiguraci |configuring], která umožňuje vytvoření více připojení a také usnadňuje přidání panelu databáze do Tracy debugger baru. Tento zápis vytvoří krom `Nette\Database\Connection` také službu `Nette\Database\Context`, která je nutná pro práci s vrstvou Database\Table.
 
 /--code neon
 	database:
 		default:
-			dsn:          "mysql:host=127.0.0.1;dbname=test"
-			user:         "root"
-			password:     "password"
-			options:      [PDO::MYSQL_ATTR_COMPRESS = true]
-			debugger:     true        # panel v debugger baru
-			explain:      true        # explain dotazů v debugger bar
-			conventions:  discovered  # nebo static nebo vaší jméno třídy, výchozí je discovered
-			autowired:    true
-		anotherConnection:
-			dsn: ...
-			autowired: false
+			dsn: "mysql:host=127.0.0.1;dbname=test"
+			user: "root"
+			password: "password"
+			options:
+				lazy: true
 \--
+
+Více informací v odstavci [#pokročilé nastavení spojení]
 
 
 Dotazy
@@ -98,6 +73,87 @@ $rows = $result->fetchAll(); //vrátí všechny řádky jako pole
 
 .[note]
 Nad třídou `ResultSet` je možné iterovat pouze jednou, pokud potřebujeme iterovat vícekrát, je nutno tento objekt převést na pole metodou `fetchAll()`
+
+
+Podporované databáze
+====================
+Nette\Database si vytvoří vlastní vnitřní ovladač a nastaví své chování podle toho, jaký používáte databázový server. Nette podporuje následující databáze:
+
+|* Databázový server  |* DSN jméno  |* Podpora v Database |* Podpora v Database\Table
+| MySQL               | mysql       | ANO                 | ANO
+| PostgreSQL          | pgsql       | ANO                 | ANO
+| Sqlite 3            | sqlite      | ANO                 | ANO
+| Sqlite 2            | sqlite2     | ANO                 | -
+| Oracle              | oci         | ANO                 | -
+| MS SQL (PDO_SQLSRV) | sqlsrv      | ANO                 | ANO
+| MS SQL (PDO_DBLIB)  | mssql       | ANO                 | -
+| ODBC                | odbc        | ANO                 | -
+
+Pokročilé nastavení spojení
+===========================
+
+
+Volitelný čtvrtý parametr konstruktoru [Connection |api:Nette\Database\Connection] umožňuje přidat dodatečné parametry. Tyto volby jsou předány jak konstruktoru PDO, tak vnitřnímu ovladači, mohou tedy obsahovat konfiguraci pro instanci PDO i pro instanci ovladače.
+
+Připojení může být vytvořeno "líně". To znamená, že připojení k databázi je navázáno až ve chvíli, kdy je poprvé potřeba, ne když je vytvořena instance `Connection`. Toto chování můžeme zapnout přidáním konfigurace `'lazy' => TRUE`.
+
+Ovladač databáze je zvolen podle použitého DSN jména. Můžeme ale poskytnout vlastní implementaci ovladače. To uděláme předáním jména ovladače jako hodnoty parametru `driverClass`.
+
+/--code php
+$connection = new Connection($dsn, $user, $password, array(
+	'lazy' => FALSE,
+	'driverClass' => 'App\JmenoVasiVlastniImplementaceOvladace'
+));
+\--
+
+V běžné Nette aplikaci, kde používáme celé Nette a nikoliv jen samostatnou databázovou vrstvu, vytváříme vždy spojení pomocí [aplikační konfigurace |configuring]. Ta je velmi intuitivní a umožní nám také snadno používat vrstvu [Database\Table |database-table]:
+
+/--code neon
+	database:
+		default:
+			dsn: "mysql:host=127.0.0.1;dbname=test"
+			user: "root"
+			password: "password"
+			options:
+				PDO::MYSQL_ATTR_COMPRESS: true
+				lazy: true
+			debugger: true # panel v debugger baru
+			explain: true # explain dotazů v debugger bar
+			conventions: discovered  # nebo static nebo vaší jméno třídy, výchozí je discovered
+			autowired: true # defaultní u prvního spojení
+		anotherConnection:
+			dsn: ...
+			autowired: false #defaultní u druhého a dalšího spojení
+\--
+
+Práce se databázovými službami
+==============================
+
+Každé takto definované spojení vytvoří dvě služby - `Nette\Database\Connection` pod názvem `database.[NAME].connection` (tedy např. `database.default.connection`) a `Nette\Database\Context` pod názvem `database.default.context` (např. `database.default.context`).
+
+Pokud si při práci s databází vystačíme s psaním SQL dotazů, jako jsme viděli v této kapitole, bude nám stačit první jmenovaná služba. Pokud však chceme využívat všechny možnosti vrstvy Database\Table, musíme pracovat se službou `Context`.
+
+V případě, že používáme pouze jedno databázové spojení, nemusíme se o nic starat a vyžádáme si jej [pomocí DI |di-usage].
+
+/--code php
+class UserManager
+{
+
+	private $connection;
+
+	public function __construct(Nette\Database\Connection $connection) {
+		$this->connection = $connection;
+		//nebo  si vyzadame Nette\Database\Context, pokud chceme pracovat s Database\Table
+	}
+}
+\--
+
+Jestliže však máme definováno více spojení, je nutné ta spojení, která nejsou autowirovaná (obvykle druhé a následující) předat ručně v konfiguraci:
+/--code neon
+services:
+	- UserManager(@database.anotherConnection.connection) #nebo @database.anotherConnection.context
+\--
+
 
 
 {{toc: title}}

--- a/cs/database.texy
+++ b/cs/database.texy
@@ -2,7 +2,7 @@ Databáze
 ********
 
 /--div .[perex]
-Nette Framework vám poskytuje vrstvu pro výrazně pohodlnější práci s databázemi. Co umí?
+Nette Framework nám poskytuje vrstvu pro výrazně pohodlnější práci s databázemi. Co umí?
 
 - snadno skládat SQL dotazy
 - snadno získávat data
@@ -10,10 +10,10 @@ Nette Framework vám poskytuje vrstvu pro výrazně pohodlnější práci s data
 \--
 
 
-Třída [api:Nette\Database\Connection] tvoří obálku nad [php:PDO] a reprezentuje připojení k databázi. Základní funkcionalitu poskytuje [api:Nette\Database\Context]. [Nette\Database\Table | database-table] poskytuje pokročilou vrstvu pro práci s tabulkami.
+Třída [api:Nette\Database\Connection] tvoří obálku nad [php:PDO] a reprezentuje připojení k databázi. Tato třída také poskyuje základní funkcionalitu pokládání dotazů. Vstupní bránou do vrstvy [Nette\Database\Table | database-table], která poskytuje pokročilou pro práci s tabulkami, je pak třída [api:Nette\Database\Context]. .
 
 Vytvoření připojení
--------------------
+===================
 
 Pro vytvoření nového připojení k databázi stačí vytvořit novou instanci třídy [api:Nette\Database\Connection]:
 
@@ -36,9 +36,9 @@ Nette\Database si vytvoří vlastní vnitřní ovladač a nastaví své chován�
 
 Volitelný čtvrtý parametr konstruktoru [Connection |api:Nette\Database\Connection] umožňuje přidat dodatečné parametry. Tyto volby jsou předány jak konstruktoru PDO, tak vnitřnímu ovladači, mohou tedy obsahovat konfiguraci pro instanci PDO i pro instanci ovladače.
 
-Všechna připojení jsou v základu vytvořená "líně". To znamená, že připojení k databázi je navázáno až ve chvíli, kdy je poprvé potřeba, ne když je vytvořena instance `Connection`. Toto chování můžete zakázat přidáním konfigurace `'lazy' => FALSE`.
+Všechna připojení jsou v základu vytvořená "líně". To znamená, že připojení k databázi je navázáno až ve chvíli, kdy je poprvé potřeba, ne když je vytvořena instance `Connection`. Toto chování můžeme zakázat přidáním konfigurace `'lazy' => FALSE`.
 
-Ovladač databáze je zvolen podle použitého DSN jména. Můžete ale poskytnout vlastní implementaci ovladače. To uděláte předáním jména ovladače jako hodnoty parametru `driverClass`.
+Ovladač databáze je zvolen podle použitého DSN jména. Můžeme ale poskytnout vlastní implementaci ovladače. To uděláme předáním jména ovladače jako hodnoty parametru `driverClass`.
 
 /--code php
 $connection = new Connection($dsn, $user, $password, array(
@@ -47,7 +47,10 @@ $connection = new Connection($dsn, $user, $password, array(
 ));
 \--
 
-Nejjednodušším způsobem, jak nastavit připojení k databázi, je v aplikační konfiguraci, která umožňuje vytvoření více připojení a také usnadňuje přidání panelu databáze do Tracy debugger baru.
+Vytvoření pomocí aplikační konfigurace
+--------------------------------------
+
+Nejjednodušším způsobem, jak nastavit připojení k databázi, je v [aplikační konfiguraci |configuring], která umožňuje vytvoření více připojení a také usnadňuje přidání panelu databáze do Tracy debugger baru.
 
 /--code neon
 	database:
@@ -67,24 +70,35 @@ Nejjednodušším způsobem, jak nastavit připojení k databázi, je v aplikač
 
 
 Dotazy
-------
+======
 
-Základní funkcionalitu poskytuje [api:Nette\Database\Context]. Database\Context umožňuje jednoduše pokládat databázové dotazy voláním metody `query`:
+Database\Connection umožňuje jednoduše pokládat databázové dotazy voláním metody `query`, která nám vrací [ResultSet |api:Nette\Database\ResultSet].
 
 /--php
-use Nette\Database\Context;
 
-$database = new Context($connection);
-
-$database->query('INSERT INTO users', array( // parametr může být pole
+$connection->query('INSERT INTO users', array( // parametr může být pole
 	'name' => 'Jim',
 	'created' => new DateTime, // nebo objekt DateTime
 	'avatar' => fopen('image.gif', 'r'), // nebo soubor
 ), ...); // je možné také provést více vložení najednou
 
-$database->query('UPDATE users SET ? WHERE id=?', $data, $id);
-$database->query('SELECT * FROM categories WHERE id=?', 123)->dump();
+$connection->query('UPDATE users SET ? WHERE id=?', $data, $id);
+
+$result = $connection>query('SELECT * FROM users WHERE id=?', 123);
+
+//ResultSet implemetuje iterator
+foreach ($result as $row) {
+	echo $row['name'];
+}
+
+$rows = $result->fetch(); //vrátí následující řádek nebo FALSE
+$rows = $result->fetchAll(); //vrátí všechny řádky jako pole
 \--
+
+
+.[note]
+Nad třídou `ResultSet` je možné iterovat pouze jednou, pokud potřebujeme iterovat vícekrát, je nutno tento objekt převést na pole metodou `fetchAll()`
+
 
 {{toc: title}}
 {{themeicon: icon-database.png}}

--- a/cs/database.texy
+++ b/cs/database.texy
@@ -129,7 +129,7 @@ V běžné Nette aplikaci, kde používáme celé Nette a nikoliv jen samostatno
 Práce se databázovými službami
 ==============================
 
-Každé takto definované spojení vytvoří dvě služby - `Nette\Database\Connection` pod názvem `database.[NAME].connection` (tedy např. `database.default.connection`) a `Nette\Database\Context` pod názvem `database.default.context` (např. `database.default.context`).
+Každé takto definované spojení vytvoří dvě služby - `Nette\Database\Connection` pod názvem `database.[NAME].connection` (tedy např. `database.default.connection`) a `Nette\Database\Context` pod názvem `database.[NAME].context` (např. `database.default.context`).
 
 Pokud si při práci s databází vystačíme s psaním SQL dotazů, jako jsme viděli v této kapitole, bude nám stačit první jmenovaná služba. Pokud však chceme využívat všechny možnosti vrstvy Database\Table, musíme pracovat se službou `Context`.
 


### PR DESCRIPTION
- oprava par typo
- kapitola database pouziva Connection pro dotazy, neni pouzit Context (ale asi pak v database-table zminim, ze ma skoro stejny api), pridany nejaky ukazky
- aktualizovano, jak se vytvari Context (a presunuto do database-table)
- pridano info, jak zapisovat dotazy, aby to bylo spravne escapovany

co jeste asi udelat:
- [x] v kapitole database presunout rucni vytvareni dolu, podobne jako je to v database-table
- [x] tu tabulku s podporou v databazich taky presunout dolu
- [ ] konfiguraci v neonu zkratit, rozsirene veci presunout do kapitoly configuring

Jeste nejaky napady?
