### PR TITLE
Repaired rewrite rule flags

### DIFF
--- a/cs/routing.texy
+++ b/cs/routing.texy
@@ -304,8 +304,8 @@ Přesměrování všech adres u již zaběhnuté aplikace lze docílit pomocí s
 <IfModule mod_rewrite.c>
 	RewriteEngine On
 	...
-	RewriteCond %{HTTPS} !=on
-	RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [L, R=301]
+	RewriteCond %{HTTPS} off
+	RewriteRule .* https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
 	...
 </IfModule>
 \--

--- a/en/routing.texy
+++ b/en/routing.texy
@@ -369,8 +369,8 @@ Forward all addresses for already well-established applications can be achieved 
 <IfModule mod_rewrite.c>
 	RewriteEngine On
 	...
-	RewriteCond %{HTTPS} !=on
-	RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [L, R=301]
+	RewriteCond %{HTTPS} off
+	RewriteRule .* https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
 	...
 </IfModule>
 \--


### PR DESCRIPTION
Rewrite rule flags use comma as separator, cannot be used space.
With spaces, server throw error 500.

`!= on` can be simplified as `off`
`^(.*)$` can be simplified as `.*`