### PR TITLE
Removed missing config option in 2.4.

### DIFF
--- a/en/configuring.texy
+++ b/en/configuring.texy
@@ -264,7 +264,6 @@ DI container
 /--neon
 	di:
 		debugger: true  #debugger bar panel
-		accessors: true  #enables $container->serviceName shortcut
 \--
 
 


### PR DESCRIPTION
According to commit https://github.com/nette/di/commit/eba68180013a5f9d81ce892984dca758c178be57 accessors options was removed in Nette 2.4 so it should not be mentioned in documentation.