### PR TITLE
Added info about limitation of Latte Context-Aware Escaping in JavaScript strings.

### DIFF
--- a/latte/cs/homepage.texy
+++ b/latte/cs/homepage.texy
@@ -256,6 +256,27 @@ Pokud bude proměnná `$movie` obsahovat řetězec `'Amarcord & 8 1/2'`, vygener
 Díky Context-Aware Escaping je šablona jednoduchá a vaše aplikace přitom bude perfektně zabezpečená proti Cross Site Scripting. Dokonce je možné zcela nativně používat PHP proměnné uvnitř JavaScriptu!
 
 
+Omezení
+-------
+
+Pozor, Latte makra nejsou podporována uvnitř řetězců v JavaScriptu a Context-Aware Escaping může mít, jak je vidět v příkladu níže, nepředvídané výsledky.
+
+/--html
+<p onclick='alert("Film {$movie} mám fakt rád.")'>{$movie}</p>
+\--
+
+Všimněte si nadbytečných uvozovek (zakódovaných jako `&quot;`) ve vygenerovaném kódu níže. Skript bude končit syntaktickou chybou.
+
+/--html
+<p onclick='alert("Film &quot;Amarcord &amp; 8 1\/2&quot; mám fakt rád")'>Amarcord &amp; 8 1/2</p>
+\--
+
+Toto omezení lze obejít ručním spojením řetězců:
+
+/--html
+<p onclick='alert("Film " + {$movie} + " mám fakt rád.")'>{$movie}</p>
+\--
+
 
 Hezký výstup
 ============

--- a/latte/en/homepage.texy
+++ b/latte/en/homepage.texy
@@ -315,6 +315,28 @@ If `$movie` variable stores `'Amarcord & 8 1/2'` string it generates the followi
 Thanks to Context-Aware Escaping the template is simple and your application perfectly secured against Cross Site Scripting. You can use PHP variables natively inside the JavaScript!
 
 
+Limitation
+----------
+
+Note that Latte macros inside JavaScript strings are not supported and Context-Aware Escaping may produce unexpected results as seen in example below:
+
+/--html
+<p onclick='alert("My favorite movie is {$movie}.")'>{$movie}</p>
+\--
+
+It generates the following output. Notice the excessive `&quot;`'s that will break the script:
+
+/--html
+<p onclick='alert("My favorite movie is &quot;Amarcord &amp; 8 1\/2&quot;.")'>Amarcord &amp; 8 1/2</p>
+\--
+
+The workaround for this is to concatenate strings manually:
+
+/--html
+<p onclick='alert("My favorite movie is " + {$movie} + ".")'>{$movie}</p>
+\--
+
+
 A pretty output
 ===============
 


### PR DESCRIPTION
As discussed here: https://github.com/nette/latte/issues/149