### PR TITLE
tracy-extensions: correct CSS classes and attributes

### DIFF
--- a/tracy/cs/extensions.texy
+++ b/tracy/cs/extensions.texy
@@ -66,24 +66,24 @@ Měl by vypadat přibližně takto:
 /--html
 <h1>Titulek</h1>
 
-<div class="nette-inner">
+<div class="tracy-inner">
     ... obsah ...
 </div>
 \--
 
 Titulek by měl být buď stejný, jako titulek tabu, nebo může obsahovat údaje navíc.
 
-Je třeba počítat s tím, že jedno rozšíření se může zaregistrovat i vícekrát, kupříkladu s jiným nastavením, takže pro stylování nelze používat CSS id, ale jen class, a to ve tvaru `nette-addons-<NazevTridy>[-<volitelné>]`. Třídu pak zapište do divu společně s třídou `nette-inner`. Při zápisu CSS je užitečné psát `#nette-debug .trida`, protože pravidlo pak má vyšší prioritu než reset.
+Je třeba počítat s tím, že jedno rozšíření se může zaregistrovat i vícekrát, kupříkladu s jiným nastavením, takže pro stylování nelze používat CSS id, ale jen class, a to ve tvaru `tracy-addons-<NazevTridy>[-<volitelné>]`. Třídu pak zapište do divu společně s třídou `tracy-inner`. Při zápisu CSS je užitečné psát `#tracy-debug .trida`, protože pravidlo pak má vyšší prioritu než reset.
 
 Výchozí styly
 =============
 
-V panelu jsou předstylované `<a>`, `<table>`, `<pre>`, `<code>` a dále můžete využít třídy: `.nette-hidden` a .`nette-collapsed` pro skryté prvky. Pokud chcete vytvořit odkaz, který skrývá a zobrazuje jiný prvek, propojte je atributy `rel` a `id`:
+V panelu jsou předstylované `<a>`, `<table>`, `<pre>`, `<code>` a dále můžete využít třídu .`tracy-collapsed` pro skryté prvky. Pokud chcete vytvořit odkaz, který skrývá a zobrazuje jiný prvek, propojte je atributy `href` a `id`:
 
 /--html
-<a href='#' rel='#nette-addons-NazevTridy-{$counter}'>Detaily&nbsp;&#x25ba;</a>
+<a href='#tracy-addons-NazevTridy-{$counter}'>Detaily&nbsp;&#x25ba;</a>
 
-<div id="nette-addons-NazevTridy-{$counter}">...</div>
+<div id="tracy-addons-NazevTridy-{$counter}">...</div>
 \---
 
 Counter použijte statický, aby se nevytvářely duplicitní ID na jedné stránce.

--- a/tracy/en/extensions.texy
+++ b/tracy/en/extensions.texy
@@ -67,24 +67,25 @@ Should look something like this:
 /--html
 <h1>Title</h1>
 
-<div class="nette-inner">
+<div class="tracy-inner">
     ... content ...
 </div>
 \--
 
 Title should either be the same as in tab or contain additional information.
 
-One extension can be registered multiple times, so it's recommended not to use `id` attribute for styling. You can use classes, preferably in `nette-addons-<class-name>[-<optional>]` format. When creating CSS, it's better to use `#nette-debug .class`, because such rule has higher priority than reset.
+One extension can be registered multiple times, so it's recommended not to use `id` attribute for styling. You can use classes, preferably in `tracy-addons-<class-name>[-<optional>]` format. When creating CSS, it's better to use `#tracy-debug .class`, because such rule has higher priority than reset.
 
 Default styles
 --------------
 
-In the panel, elements `<a>`, `<table>`, `<pre>`, `<code>` have default styles. You can also use `.nette-hidden` and `.nette-collapsed` for hidden elements. For creating a link for hiding or displaying other element, connect them with `rel` and `id` attributes.
+In the panel, elements `<a>`, `<table>`, `<pre>`, `<code>` have default styles. You can also use `.tracy-collapsed` for hidden elements. For creating a link for hiding or displaying other element, connect them with `href` and `id` attributes.
 
 /--html
-<a href='#' rel='#nette-addons-className-{$counter}'>Details&nbsp;&#x25ba;</a>
+<a href='#tracy-addons-className-{$counter}'>Detail&nbsp;&#x25ba;</a>
 
-<div id="nette-addons-className-{$counter}">...</div>
+<div id="tracy-addons-className-{$counter}">...</div>
+
 \---
 
 Use static counter to prevent duplicate IDs on one page.


### PR DESCRIPTION
CSS classes - replace .nette- prefix with .tracy-
attribues - use 'href' instead of 'rel'