### PR TITLE
coding-standard: drop Nette\Object ancesstor for all

### DIFF
--- a/www/en/coding-standard.texy
+++ b/www/en/coding-standard.texy
@@ -206,7 +206,7 @@ Class members implementation should follow this order as it is practical:
   b) protected
   c) private
 
-All instantiable classes should use to `Nette\SmartObject` or `Nette\StaticClass` traits.
+All instantiable classes should use `Nette\SmartObject` or `Nette\StaticClass` traits.
 
 
 Constants

--- a/www/en/coding-standard.texy
+++ b/www/en/coding-standard.texy
@@ -206,7 +206,7 @@ Class members implementation should follow this order as it is practical:
   b) protected
   c) private
 
-All instantiable classes should use `Nette\SmartObject` or `Nette\StaticClass` traits.
+All instantiable classes should use `Nette\SmartObject` trait and non-instantiable `Nette\StaticClass` trait.
 
 
 Constants

--- a/www/en/coding-standard.texy
+++ b/www/en/coding-standard.texy
@@ -206,6 +206,8 @@ Class members implementation should follow this order as it is practical:
   b) protected
   c) private
 
+All instantiable classes should use to `Nette\SmartObject` or `Nette\StaticClass` traits.
+
 
 Constants
 ---------

--- a/www/en/coding-standard.texy
+++ b/www/en/coding-standard.texy
@@ -206,8 +206,6 @@ Class members implementation should follow this order as it is practical:
   b) protected
   c) private
 
-The ultimate ancestor of all instantiable classes should be `Nette\Object`.
-
 
 Constants
 ---------


### PR DESCRIPTION
Probably not the case anymore, since Smart traits came and "Object" is a keyword