### PR TITLE
Typo: trailing ```

### DIFF
--- a/www/en/coding-standard.texy
+++ b/www/en/coding-standard.texy
@@ -451,4 +451,3 @@ Some annotations like `@param` or `@return` require data type. These can be:
 - `array` for common arrays, but
 - `string[]`, `int[]`, 'ClassName[]` for single-type arrays.
 - Dynamic type list is concatenated by `|` like `int|string|ClassName`.
-```


### PR DESCRIPTION
![coding_standards___nette_framework](https://user-images.githubusercontent.com/538058/27529005-2dbbd5c8-5a53-11e7-835b-a6b365350621.png)
