### PR TITLE
String: remove deprecated random() method

### DIFF
--- a/cs/homepage.texy
+++ b/cs/homepage.texy
@@ -66,7 +66,7 @@
 - [Vyhledávání souborů a adresářů | finder]
 - [Atomické operace | atomicity]
 - [Validace | validators]
-- [Utility | utils] (funkce pro práci s [řetězci | strings], [poli | arrays], [HTML elementy | HTML elements], [datem | datetime] a [URL | URLs])
+- [Utility | utils] (funkce pro práci s [řetězci | strings], [generování řetězců | random], [poli | arrays], [HTML elementy | HTML elements], [datem | datetime] a [URL | URLs])
 - Nástroje: [Code-Checker], [Composer]
 
 \---

--- a/cs/random.texy
+++ b/cs/random.texy
@@ -1,0 +1,18 @@
+Random - Nette\Utils\Random
+***************************
+
+.[perex]
+[Nette\Utils\Random |api:] je statická třída vhodna pro generování řetězců.
+
+
+random(int $length=10, string $charlist=`'0-9a-z'`): string .{toc: random()}
+----------------------------------------------------------------------------
+
+Vygeneruje náhodný řetězec o dané délce ze znaků specifikovaných parametrem `$charlist`. Lze používat i intervaly zapsané jako třeba `0-9`.
+
+/--php
+use Nette\Utils\Random;
+
+echo Strings::random(); // '6zq3a1nl8n'
+echo Strings::random(5, 'A-Z'); // 'HLKUR'
+\--

--- a/cs/strings.texy
+++ b/cs/strings.texy
@@ -214,17 +214,6 @@ echo Strings::chr(0xA9); // vytvoří znak '©'
 \--
 
 
-random($length=10, $charlist=`'0-9a-z'`) .{toc: random()}
----------------------------------------------------------
-
-Vygeneruje náhodný řetězec o dané délce ze znaků specifikovaných parametrem `$charlist`. Lze používat i intervaly zapsané jako třeba `0-9`.
-
-/--php
-echo Strings::random(); // '6zq3a1nl8n'
-echo Strings::random(5, 'A-Z'); // 'HLKUR'
-\--
-
-
 Kódování
 ========
 

--- a/en/homepage.texy
+++ b/en/homepage.texy
@@ -65,7 +65,7 @@
 - [Browsing files on disk | finder]
 - [Atomic Operations | atomicity]
 - [Validation | validators]
-- [Utils] (functions for [strings], [arrays], [HTML elements], [DateTime] and [URLs])
+- [Utils] (functions for [strings], [string generating | random]  [arrays], [HTML elements], [DateTime] and [URLs])
 - Tools: [Code-Checker], [Composer]
 
 \---

--- a/en/random.texy
+++ b/en/random.texy
@@ -1,0 +1,18 @@
+Random - Nette\Utils\Random
+***************************
+
+.[perex]
+[Nette\Utils\Random |api:] is a static class used for string generating.
+
+
+random(int $length=10, string $charlist=`'0-9a-z'`): string .{toc: random()}
+----------------------------------------------------------------------------
+
+Generates a random string of given length from characters specified in second argument. Supports intervals, such as `0-9` or `A-Z`.
+
+/--php
+use Nette\Utils\Random;
+
+echo Strings::random(); // '6zq3a1nl8n'
+echo Strings::random(5, 'A-Z'); // 'HLKUR'
+\--

--- a/en/strings.texy
+++ b/en/strings.texy
@@ -233,20 +233,6 @@ echo Strings::chr(0xA9); // creates '©'
 \--
 
 
-Generating a string
-===================
-
-random($length=10, $charlist=`'0-9a-z'`) .{toc: random()}
----------------------------------------------------------
-
-Generates a random string of given length from characters specified in second argument. Supports intervals, such as `0-9` or `A-Z`.
-
-/--php
-echo Strings::random(); // '6zq3a1nl8n'
-echo Strings::random(5, 'A-Z'); // 'HLKUR'
-\--
-
-
 Regular expressions
 ===================
 


### PR DESCRIPTION
This PR removes deprecated [`Strings::random()`](https://api.nette.org/2.4/source-Utils.Strings.php.html#418-426)