### PR TITLE
Configuration: repair headlines, add some code examples

### DIFF
--- a/cs/configuring.texy
+++ b/cs/configuring.texy
@@ -370,6 +370,19 @@ services:
 
 \--
 
+Vygeneruje:
+
+/--php
+function createServiceDatabase()
+{
+	return new Nette\Database\Connection(
+		$this->parameters['dsn'],
+		$this->parameters['user'],
+		$this->parameters['password']
+	);
+}
+\--
+
 Autowiring umí odkazy na jiné služby doplnit automaticky, takže lze parametry úplně vynechat:
 
 /--code neon
@@ -383,7 +396,7 @@ Pokud služba `cacheStorage` neexistuje, můžeme jako parametr uvést výsledek
 setup:
 	- setCacheStorage( Factory::createStorage() )
 
-# nebo metody jiné služby:
+	# nebo metody jiné služby:
 	- setCacheStorage( @factory::createStorage() )
 \--
 
@@ -394,6 +407,12 @@ setup:
 	- setCacheStorage( Nette\Caching\Storages\FileStorage(%tempDir%) )
 \--
 
+Vygeneruje:
+
+/--php
+$service->setCacheStorage(new Nette\Caching\Storages\FileStorage(...));
+\--
+
 Lze nastavovat i hodnoty proměnných:
 
 substitutions
@@ -402,6 +421,11 @@ setup:
 	- $substitutions( [db: test] )
 \--
 
+Vygeneruje:
+
+/--php
+$service->substitutions = ['db' => 'test'];
+\--
 
 Kompletní příklad:
 

--- a/en/configuring.texy
+++ b/en/configuring.texy
@@ -112,7 +112,7 @@ $configurator->addParameters([
 
 
 Framework configuration
-***********************
+=======================
 
 Configuration is usually written in NEON format. Have fun trying out the syntax at http://ne-on.org.
 Many features of Nette Framework can be set up in configuration file
@@ -132,7 +132,7 @@ Many features of Nette Framework can be set up in configuration file
 
 
 Sessions
-========
+--------
 
 Here you can set all [directives |php:session.configuration] (in camelCase format).
 
@@ -151,7 +151,7 @@ Read more on [session configuration | sessions#Session configuration].
 
 
 Application
-===========
+-----------
 
 /--neon
 	application:
@@ -166,7 +166,7 @@ Application
 
 
 Routing
-=======
+-------
 
 /--neon
 	routing:
@@ -180,7 +180,7 @@ Routing
 
 
 HTTP headers
-============
+------------
 
 /--neon
 	http:
@@ -191,7 +191,7 @@ For security reasons Nette Framework sends HTTP header `X-Frame-Options: SAMEORI
 
 
 HTTP proxies
-============
+------------
 
 You can define your http proxy, so that HTTP request's remote address and remote host will be correct.
 
@@ -202,7 +202,7 @@ You can define your http proxy, so that HTTP request's remote address and remote
 
 
 Security
-========
+--------
 
 By filling in `users` option you create `SimpleAuthenticator`, by defining `roles` or `resources` you create `Nette\Security\Permission` authorizator. More in [User Authorization and Privileges |access-control].
 
@@ -224,7 +224,7 @@ By filling in `users` option you create `SimpleAuthenticator`, by defining `role
 
 
 Mailing
-=======
+-------
 
 Default mailer is `SendmailMailer`. By setting `smtp` you activate `SmtpMailer`.
 
@@ -242,7 +242,7 @@ Default mailer is `SendmailMailer`. By setting `smtp` you activate `SmtpMailer`.
 
 
 Database
-========
+--------
 
 You can define multiple database connections, if you do so you can set which one will be [automatically injected |configuring#auto-wiring] to your services by the `autowired` option. The following code shows how to set up one connection called `default`.
 
@@ -263,7 +263,7 @@ This creates service `@nette.database.default` and sets reflection and cache for
 
 
 Forms
-=====
+-----
 
 You can change default validation error messages.
 
@@ -278,7 +278,7 @@ You can change default validation error messages.
 
 
 Latte
-=====
+-----
 
 You can turn on and off XHTML rendering mode and register custom macros. Custom macros may be passed either as a class name or as a service reference. The default called method is `install`, you may change it by appending a double colon and a custom method name.
 
@@ -296,7 +296,7 @@ You can turn on and off XHTML rendering mode and register custom macros. Custom 
 
 
 DI container
-============
+------------
 
 /--neon
 	di:
@@ -305,7 +305,7 @@ DI container
 
 
 Tracy debugger
-==============
+--------------
 
 /--neon
 	tracy:
@@ -326,7 +326,7 @@ Tracy debugger
 
 
 Low-level modifications
-=======================
+-----------------------
 
 All these settings affect final DI container. The `alteration` flag is informative and says that we only alter an existing service. If you need to tune these services by yourself, you can redefine them:
 
@@ -343,7 +343,7 @@ services:
 
 
 Custom services
-===============
+---------------
 
 /--code neon
 services:
@@ -374,7 +374,7 @@ function createServiceDatabase()
 
 
 Setup
-=====
+-----
 
 /--code neon
 services:
@@ -388,12 +388,12 @@ services:
 Generates:
 
 /--php
-	function createServiceDatabase()
-	{
-		$service = new Nette\Database\Connection(...);
-		$service->setCacheStorage($this->cacheStorage);
-		return $service;
-	}
+function createServiceDatabase()
+{
+	$service = new Nette\Database\Connection(...);
+	$service->setCacheStorage($this->cacheStorage);
+	return $service;
+}
 \--
 
 Autowiring feature adds dependencies automatically, so they don't even have to be mentioned:
@@ -409,7 +409,7 @@ In case the `cacheStorage` service does not exist, it is possible to use a resul
 setup:
 	- setCacheStorage( Factory::createStorage() )
 
-# or a method of other service:
+	# or a method of other service:
 	- setCacheStorage( @factory::createStorage() )
 \--
 
@@ -418,8 +418,12 @@ Alternatively a newly created class instance:
 /--code neon
 setup:
 	- setCacheStorage( Nette\Caching\Storages\FileStorage(%tempDir%) )
+\--
 
-# generates: $service->setCacheStorage(new Nette\Caching\Storages\FileStorage(...));
+Generates:
+
+/--php
+$service->setCacheStorage(new Nette\Caching\Storages\FileStorage(...));
 \--
 
 You can also set a value of a property:
@@ -428,8 +432,12 @@ substitutions
 /--code neon
 setup:
 	- $substitutions( [db: test] )
+\--
 
-# generates: $service->substitutions = ['db' => 'test'];
+Generates:
+
+/--php
+$service->substitutions = ['db' => 'test'];
 \--
 
 Full example:
@@ -460,7 +468,7 @@ services:
 
 
 Anonymous services
-==================
+------------------
 
 Time after time there are services that are in fact not referenced anywhere else in config files. Naming these services in this case is not necessary. To define an anonymous service, use the following syntax:
 
@@ -486,7 +494,7 @@ Keep in mind that from a nature of anonymous services, it is not possible to reg
 
 
 Auto-wiring
-===========
+-----------
 
 Auto-wiring feature can automatically pass dependencies into constructor and methods of the service. It uses typehinting and `@return` annotations. There can be only one service matching the type in the container, otherwise an exception is thrown.
 
@@ -508,7 +516,7 @@ When modifying the Nette Framework's core services we need to make sure the cont
 
 
 Multiple configuration files
-****************************
+============================
 
 Use `includes` section to add more configuration files.
 


### PR DESCRIPTION
Opravil jsem spatne vygenerovane odkazy, resp. toc.

![configuring___nette_framework](https://user-images.githubusercontent.com/538058/28256640-a2c9bdae-6ac4-11e7-8137-bcc36697235e.png)
