### PR TITLE
Removed an excessive explanation

### DIFF
--- a/en/ajax.texy
+++ b/en/ajax.texy
@@ -79,9 +79,6 @@ Thanks to invalidation of snippets we know exactly which parts of which elements
 Macro `{snippet} … {/snippet}` .{toc: Macro snippet}
 ----------------------------------------------------
 
-Nette is based on the idea of **logical**, not **graphical** elements, i.e. a descendant of Control does not represent a rectangular area on a page, but a logical component that that can render even into various forms. (for instance a hypothetical component DataGrid can have a method for rendering the grid and another one for rendering the “paginator”, and so on). Each element can also be rendered multiple times on a single page; or conditionally, or every time with a different template, etc.
-Therefore it is not possible to call some `render` method of every invalid object. The approach to the render must be the same as when the whole page is being rendered.
-
 Rendering of the page proceeds very similarly as in case of a regular request: the same templates are loaded, etc. The vital part is, however, to leave out the parts that are not supposed to reach the output and those that are shall be associated with an identifier and be sent to the user in a comprehensible format for a JavaScript handler.
 
 Syntax


### PR DESCRIPTION
The purpose of these docs is probably more about helping the reader *use* the framework than about helping them understand how exactly it works internally or what was the reasoning behind the internal workings ("Therefore it is not possible to call some render method of every invalid object"). The removed paragraph serves no purpose other than to add noise to something the following paragraph explains in the first sentence ("Rendering of the page proceeds very similarly as in case of a regular request") and expand on what are snippets (which is a term that has been used previously and should therefore have been explained previously).