### PR TITLE
Fix EN code example in "Template from string"

### DIFF
--- a/latte/en/homepage.texy
+++ b/latte/en/homepage.texy
@@ -413,9 +413,9 @@ Template from string
 You can load template from strings using `Latte\Loaders\StringLoader`:
 
 /--php
-$latte->setLoader(new Latte\Loaders\StringLoader[
+$latte->setLoader(new Latte\Loaders\StringLoader([
 	'main' => '{if true} {$var} {/if}',
-]);
+]));
 
 $latte->render('main', $parameters);
 \--


### PR DESCRIPTION
I added the missing brackets that were missing in the EN version. In the Czech version, the code was correct.