### PR TITLE
Added note about correct order of calling addAttachement method

### DIFF
--- a/en/mailing.texy
+++ b/en/mailing.texy
@@ -79,6 +79,8 @@ $mail->addAttachment('example.txt', 'Hello John!');
 $mail->addAttachment('info.zip', file_get_contents('path/to/example.zip'));
 \--
 
+Must be called after setBody or setHtmlBody method.
+
 Can be sending e-mails even easier?
 
 


### PR DESCRIPTION
New note to order of methods, because if addAttachement is called before setBody, then attachement contains contents of body instead of originally included file contents.