### PR TITLE
Update configuring.texy

### DIFF
--- a/en/configuring.texy
+++ b/en/configuring.texy
@@ -196,14 +196,14 @@ HTTP Headers
 	http:
 		frames: ...               # header X-Frame-Options
 
-	headers:
-		X-Powered-By: MyCMS       # custom HTTP header
+		headers:
+			X-Powered-By: MyCMS       # custom HTTP header
 
-	csp:                          # Content Security Policy
-		script-src: [
-			nonce                 # for browsers that support CSP2
-			self, unsafe-inline   # for browsers that support CSP1
-		]
+		csp:                          # Content Security Policy
+			script-src: [
+				nonce                 # for browsers that support CSP2
+				self, unsafe-inline   # for browsers that support CSP1
+			]
 \--
 
 For security reasons Nette Framework sends HTTP header `X-Frame-Options: SAMEORIGIN` by default, so that the page can be embedded in iframe only from pages on the same domain. This behavior may be unwanted in certain situations (for example if you are developing a facebook application). You can override this setting by `frames: yes`, `frames: http://allowed-host.com` or `frames: no`.


### PR DESCRIPTION
Wrong identation depth for http sections headers & csp.
The Czech version is ok.