### PR TITLE
How to find all presenters loaded through Composer

### DIFF
--- a/cs/configuring.texy
+++ b/cs/configuring.texy
@@ -94,6 +94,14 @@ application:
 
 `scanDirs` bude nyní obsahovat pouze hodnotu `foo`.
 
+/--json
+"config": {
+	"classmap-authoritative": true
+}
+\--
+
+Po editaci `composer.json` budou všechny presentery načítané přes Composer (včetně načítaných přes PSR-4) zaregistrovány jako služby.
+
 
 Databáze
 ========

--- a/en/configuring.texy
+++ b/en/configuring.texy
@@ -93,6 +93,14 @@ application:
 
 Now `scanDirs` will contain only `foo`.
 
+/--json
+"config": {
+	"classmap-authoritative": true
+}
+\--
+
+After `composer.json` edit will be all presenters (including PSR-4 loaded) from Composer autoloader automatically registered as services.
+
 
 Database
 ========


### PR DESCRIPTION
Nette is looking for presenters from composer classmap. By default are PSR-4 loaded classes not included in this map. With config.classmap-authoritative option are included all classes.