### PR TITLE
Form validation: Fix link to error messages of validation rules

### DIFF
--- a/cs/form-validation.texy
+++ b/cs/form-validation.texy
@@ -15,7 +15,7 @@ Na [formulářové prvky|form-fields] lze použít tyto validační pravidla:
 | `Form::VALID` | je prvek vyplněn správně? |
 | `Form::BLANK` | prvek nesmí být vyplněn |
 
-Všem validačním pravidlům můžeme přidat vlastní chybovou hlášku, nebo se použije [hláška výchozí |api:Nette\Forms\Rules::$defaultMessages], kterou můžete případně přepsat. U [vícejazyčných formulářů |localization] se hlášky automaticky překládají.
+Všem validačním pravidlům můžeme přidat vlastní chybovou hlášku, nebo se použije [hláška výchozí |api:Nette\Forms\Validator::$messages], kterou můžete případně přepsat. U [vícejazyčných formulářů |localization] se hlášky automaticky překládají.
 
 V textu chybových hlášek lze používat i speciální zástupné řetězce:
 

--- a/en/form-validation.texy
+++ b/en/form-validation.texy
@@ -15,7 +15,7 @@ The following rules are supported by most [built-in form fields |form-fields]:
 | `Form::VALID` | did input pass validation? |
 | `Form::BLANK` | the item must not be filled |
 
-We can set a custom error message to all validation rules, or a [default one |api:Nette\Forms\Rules::$defaultMessages] is used. [Multilingual forms|localization]' messages are automatically translated.
+We can set a custom error message to all validation rules, or a [default one |api:Nette\Forms\Validator::$messages] is used. [Multilingual forms|localization]' messages are automatically translated.
 
 The following special substitute strings can be utilized in error message text:
 


### PR DESCRIPTION
I tested it at https://editor.nette.org/, but there `api` helper don't generate domain to `https://api.nette.org/2.4/` but path should be good.