### PR TITLE
di-configuration: Fix typo in example code

### DIFF
--- a/cs/di-configuration.texy
+++ b/cs/di-configuration.texy
@@ -83,7 +83,7 @@ Kromě vytvoření instance třídy lze volat i metodu:
 
 /--neon
 services:
-	database: Database::create(root, password)
+	database: Database::create(root, secret)
 \--
 
 Vygenerovaný kód:

--- a/en/di-configuration.texy
+++ b/en/di-configuration.texy
@@ -83,7 +83,7 @@ In addition to creating a class instance, you can also call the method:
 
 /--neon
 services:
-	database: Database::create(root, password)
+	database: Database::create(root, secret)
 \--
 
 Result:


### PR DESCRIPTION
Fix little mistage between example `.neon` code and generated PHP code.