### PR TITLE
Docs: synchronize codes

### DIFF
--- a/cs/access-control.texy
+++ b/cs/access-control.texy
@@ -106,14 +106,14 @@ use Nette\Security as NS;
 
 class MyAuthenticator implements NS\IAuthenticator
 {
-	public $database;
+	private $database;
 
-	function __construct(Nette\Database\Context $database)
+	public function __construct(Nette\Database\Context $database)
 	{
 		$this->database = $database;
 	}
 
-	function authenticate(array $credentials)
+	public function authenticate(array $credentials)
 	{
 		list($username, $password) = $credentials;
 		$row = $this->database->table('users')
@@ -217,7 +217,7 @@ Rámcová podoba implementace vypadá takto:
 /--php
 class MyAuthorizator implements Nette\Security\IAuthorizator
 {
-	function isAllowed($role, $resource, $privilege)
+	public function isAllowed($role, $resource, $privilege)
 	{
 		return ...; // vrací true nebo false
 	}
@@ -411,7 +411,6 @@ a v presenterech pak můžete ověřit práva například v metodě startup:
 
 
 /--php
-
 	protected function startup()
 	{
 		parent::startup();
@@ -424,8 +423,6 @@ a v presenterech pak můžete ověřit práva například v metodě startup:
 Alternativou k nastavení v souboru `config.neon` je vytvoření továrny, která nám Permission nastaví. Ta pak může vypadat například následovně:
 
 /--php
-<?php
-
 namespace App\Model;
 
 class AuthorizatorFactory
@@ -500,8 +497,13 @@ services:
 /--php
 class SignPresenter extends Nette\Application\UI\Presenter
 {
-	/** @var FrontAuthenticator @inject */
-	public $authenticator;
+	/** @var FrontAuthenticator */
+	private $authenticator;
+
+	public function __construct(FrontAuthenticator $authenticator)
+	{
+		$this->authenticator = $authenticator;
+	}
 }
 \--
 

--- a/cs/ajax.texy
+++ b/cs/ajax.texy
@@ -131,7 +131,7 @@ Dynamické snippety nelze invalidovat přímo (invalidace `item-1` neudělá vů
 V příkladu výše zkrátka musíte zajistit, aby při ajaxovém požadavku byla v proměnné `$list` pouze jedna položka a tedy aby ten cyklus `foreach` naplnil pouze jeden dynamický snippet:
 
 /--php
-class HomepagePresenter extends \Nette\Application\UI\Presenter
+class HomepagePresenter extends Nette\Application\UI\Presenter
 {
 	/**
 	 * Zde je nějaká logika pro získání celého seznamu. Správně to patří do

--- a/cs/caching.texy
+++ b/cs/caching.texy
@@ -268,11 +268,13 @@ use Nette;
 
 class MyPresenter
 {
-	/**
-	 * @inject
-	 * @var Nette\Caching\IStorage
-	 */
-	public $storage;
+	/** @var Nette\Caching\IStorage */
+	private $storage;
+
+	public function __construct(Nette\Caching\IStorage $storage)
+	{
+		$this->storage = $storage;
+	}
 
 	public function actionDefault()
 	{

--- a/cs/components.texy
+++ b/cs/components.texy
@@ -36,12 +36,10 @@ Komponenta obsahuje továrnu na svou [šablonu |latte:]. Ta standardně vytvoř�
 /--php
 public function render()
 {
-	$template = $this->template;
-	$template->setFile(__DIR__ . '/poll.latte');
 	// vložíme do šablony nějaké parametry
-	$template->param = $value;
+	$this->template->param = $value;
 	// a vykreslíme ji
-	$template->render();
+	$this->template->render(__DIR__ . '/poll.latte');
 }
 \--
 
@@ -86,7 +84,7 @@ Zasílání obstarává metoda [flashMessage |api:Nette\Application\UI\Control::
 
 Příklad:
 /--php
-public function deleteFormSubmitted(Form $form)
+public function deleteFormSubmitted(Nette\Application\UI\Form $form, Nette\Utils\ArrayHash $values)
 {
 	// ... požádáme model o smazání záznamu ...
 
@@ -267,11 +265,9 @@ services:
 a nakonec ji použijeme v našem presenteru:
 
 /--php
-class PollPresenter extends \Nette\UI\Application\Presenter
+class PollPresenter extends Nette\UI\Application\Presenter
 {
-	/**
-	 * @var PollControlFactory
-	 */
+	/** @var PollControlFactory */
 	private $pollControlFactory;
 
 	public function __construct(PollControlFactory $pollControlFactory)

--- a/cs/components.texy
+++ b/cs/components.texy
@@ -84,7 +84,7 @@ Zasílání obstarává metoda [flashMessage |api:Nette\Application\UI\Control::
 
 Příklad:
 /--php
-public function deleteFormSubmitted(Nette\Application\UI\Form $form, Nette\Utils\ArrayHash $values)
+public function deleteFormSubmitted(Nette\Application\UI\Form $form, stdClass $values)
 {
 	// ... požádáme model o smazání záznamu ...
 

--- a/cs/composer.texy
+++ b/cs/composer.texy
@@ -121,7 +121,7 @@ Náš základní `composer.json` tedy může vypadat takto
 }
 \--
 
-Říkáme zde, že naše aplikace (nebo knihovna) vyžaduje balíček `nette/nette` a chce nejnovější verzi, která odpovídá `~2.4.0` (tj. nejnovější setinkovou verzi Nette 2.4), a taky že běží pouze na PHP `5.6.1` a novějším.
+Říkáme zde, že naše aplikace (nebo knihovna) vyžaduje balíček `nette/nette` a chce nejnovější verzi, která odpovídá `~2.4.0` (tj. nejnovější setinkovou verzi Nette 2.4), a taky že běží pouze na PHP `5.6.1` a novějším. Doporučujeme však používat nejnovější PHP 7.2.
 
 Máme tedy v kořenu projektu soubor `composer.json` a spustíme instalaci
 

--- a/cs/composer.texy
+++ b/cs/composer.texy
@@ -121,7 +121,7 @@ Náš základní `composer.json` tedy může vypadat takto
 }
 \--
 
-Říkáme zde, že naše aplikace (nebo knihovna) vyžaduje balíček `nette/nette` a chce nejnovější verzi, která odpovídá `~2.4.0` (tj. nejnovější setinkovou verzi Nette 2.4), a taky že běží pouze na PHP `5.6.1` a novějším. Doporučujeme však používat nejnovější PHP 7.2.
+Říkáme zde, že naše aplikace (nebo knihovna) vyžaduje balíček `nette/nette` a chce nejnovější verzi, která odpovídá `~2.4.0` (tj. nejnovější setinkovou verzi Nette 2.4), a taky že běží pouze na PHP `5.6.1` a novějším.
 
 Máme tedy v kořenu projektu soubor `composer.json` a spustíme instalaci
 

--- a/cs/database-core.texy
+++ b/cs/database-core.texy
@@ -28,7 +28,7 @@ Nicméně šikovnější způsob nabízí [aplikační konfigurace |configuring#
 Poté objekt spojení [získáme jako službu z DI kontejneru |di-usage], např.:
 
 /--php
-class PostModel
+class FooModel
 {
 	private $database;
 

--- a/cs/database-core.texy
+++ b/cs/database-core.texy
@@ -28,7 +28,7 @@ Nicméně šikovnější způsob nabízí [aplikační konfigurace |configuring#
 Poté objekt spojení [získáme jako službu z DI kontejneru |di-usage], např.:
 
 /--php
-class Model
+class PostModel
 {
 	private $database;
 

--- a/cs/di-configuration.texy
+++ b/cs/di-configuration.texy
@@ -353,7 +353,7 @@ namespace Model;
 
 class ArticleRepository
 {
-	public function __construct(\PDO $db)
+	public function __construct(PDO $db)
 	{}
 
 	public function setCacheStorage(Nette\Caching\IStorage $storage)

--- a/cs/di-configuration.texy
+++ b/cs/di-configuration.texy
@@ -356,7 +356,7 @@ class ArticleRepository
 	public function __construct(\PDO $db)
 	{}
 
-	public function setCacheStorage(\Nette\Caching\IStorage $storage)
+	public function setCacheStorage(Nette\Caching\IStorage $storage)
 	{}
 }
 \--

--- a/cs/di-usage.texy
+++ b/cs/di-usage.texy
@@ -107,7 +107,7 @@ Další způsob specifický pro DI Container v Nette. Jedná se o zvláštní p�
 /--php
 class MyService
 {
-	/** @var \App\AnotherService @inject */
+	/** @var App\AnotherService @inject */
 	public $anotherService;
 }
 \--
@@ -158,7 +158,7 @@ class MyPresenter extends Nette\Application\UI\Presenter
 	}
 
 	// 3) Předání do proměnné s anotací @inject:
-	/** @var \App\Service3 @inject */
+	/** @var Service3 @inject */
 	public $service3;
 }
 \--
@@ -203,10 +203,10 @@ Její použití v presenteru by vypadalo následovně:
 /--php
 class MyPresenter extends Nette\Application\UI\Presenter
 {
-	/** @var \App\Service1 @inject */
+	/** @var Service1 @inject */
 	public $service1;
 
-	/** @var \App\Service2 @inject */
+	/** @var Service2 @inject */
 	public $service2;
 
 	protected function createComponentMyControl()
@@ -328,7 +328,7 @@ class Service3
 	}
 
 	// 2) Přiřazení do proměnné s anotací @inject:
-	/** @var \App\Service2 @inject */
+	/** @var Service2 @inject */
 	public $service2;
 }
 \--
@@ -431,7 +431,7 @@ V presenteru pak bude stačit získat příslušnou závislost a zavolat metodu 
 /--php
 class UserPresenter extends Nette\Application\UI\Presenter
 {
-	/** @var \App\Components\IUserTableFactory @inject */
+	/** @var App\Components\IUserTableFactory @inject */
 	public $userTableFactory;
 
 	protected function createComponentUserTable()

--- a/cs/di-usage.texy
+++ b/cs/di-usage.texy
@@ -107,7 +107,7 @@ Další způsob specifický pro DI Container v Nette. Jedná se o zvláštní p�
 /--php
 class MyService
 {
-	/** @var App\AnotherService @inject */
+	/** @var AnotherService @inject */
 	public $anotherService;
 }
 \--
@@ -431,7 +431,7 @@ V presenteru pak bude stačit získat příslušnou závislost a zavolat metodu 
 /--php
 class UserPresenter extends Nette\Application\UI\Presenter
 {
-	/** @var App\Components\IUserTableFactory @inject */
+	/** @var \App\Components\IUserTableFactory @inject */
 	public $userTableFactory;
 
 	protected function createComponentUserTable()

--- a/cs/form-rendering.texy
+++ b/cs/form-rendering.texy
@@ -123,7 +123,7 @@ Formuláře lze vykreslovat i ručně a tím získat větší kontrolu nad kóde
 Velmi snadno také můžete propojit formulář s existující šablonou. Stačí jen doplnit atributy n:name:
 
 /--php
-function createComponentSignInForm()
+protected function createComponentSignInForm()
 {
 	$form = new Form;
 	$form->addText('user')->setRequired();

--- a/cs/forms.texy
+++ b/cs/forms.texy
@@ -20,6 +20,8 @@ První formulář
 Vytvoříme si v naší aplikaci jednoduchý registrační formulář. Přidáme ho do presenteru pomocí tzv. [továrny |presenters#presenter-a-komponenty]:
 
 /--php
+use Nette\Application\UI;
+
 class HomepagePresenter extends Nette\Application\UI\Presenter
 {
 	// ...
@@ -301,7 +303,9 @@ use Nette\Application\UI\Form;
 
 class SignInFormFactory
 {
-
+	/**
+	 * @return Form
+	 */
 	public function create()
 	{
 		$form = new Form;

--- a/cs/forms.texy
+++ b/cs/forms.texy
@@ -20,9 +20,7 @@ První formulář
 Vytvoříme si v naší aplikaci jednoduchý registrační formulář. Přidáme ho do presenteru pomocí tzv. [továrny |presenters#presenter-a-komponenty]:
 
 /--php
-use Nette\Application\UI;
-
-class HomepagePresenter extends UI\Presenter
+class HomepagePresenter extends Nette\Application\UI\Presenter
 {
 	// ...
 
@@ -37,7 +35,7 @@ class HomepagePresenter extends UI\Presenter
 	}
 
 	// volá se po úspěšném odeslání formuláře
-	public function registrationFormSucceeded(UI\Form $form, $values)
+	public function registrationFormSucceeded(UI\Form $form, stdClass $values)
 	{
 		// ...
 		$this->flashMessage('Byl jste úspěšně registrován.');
@@ -303,9 +301,7 @@ use Nette\Application\UI\Form;
 
 class SignInFormFactory
 {
-	/**
-	 * @return Form
-	 */
+
 	public function create()
 	{
 		$form = new Form;

--- a/cs/localization.texy
+++ b/cs/localization.texy
@@ -54,7 +54,7 @@ Překlad šablon
 Šabloně lze také nastavit překladač metodou `setTranslator()`, například v presenteru:
 
 /--php
-	function beforeRender()
+	protected function beforeRender()
 	{
 		...
 		$this->template->setTranslator($translator);

--- a/cs/migration-2-1.texy
+++ b/cs/migration-2-1.texy
@@ -140,7 +140,7 @@ Database (NDB)
 Používáte Nette Database Table (NDBT), tedy skvělou část NDB, ke které se přistupuje přes `$database->table(...)`?
 
 - metoda `table()` byl přesunuta z `Connection` do nové třídy `Nette\Database\Context`. Ta "obsahuje":https://api.nette.org/2.1/Nette.Database.Context.html všechny důležité metody pro práci s databází, takže klidně změňte `Connection` za `Context` a máte hotovo.
-- proměnné řádku `ActiveRow` jsou nyní read-only, pro změnu slouží metoda `$row->update(array('field' => 'value'))`. Věřte, že dřívější chování mělo tolik úskalí, že jiná cesta nebyla.
+- proměnné řádku `ActiveRow` jsou nyní read-only, pro změnu slouží metoda `$row->update(['field' => 'value'])`. Věřte, že dřívější chování mělo tolik úskalí, že jiná cesta nebyla.
 - změnila se tzv. backjoin syntaxe z `book_tag:tag.name` na `:book_tag.tag.name` (dvojtečka na začátku)
 - místo druhého parametru `$having` v metodě `group()` použijte metodu `having()`
 - Selection: removed support for INNER join in where statement ("commit":https://github.com/nette/nette/commit/68314840e2429351d1e37e00c6070a21bdc36744)

--- a/cs/multiplier.texy
+++ b/cs/multiplier.texy
@@ -15,7 +15,7 @@ Podstatou Multiplieru je, že vystupuje v pozici rodiče, který si své potomky
 protected function createComponentShopForm()
 {
 	return new Multiplier(function () {
-		$form = new Form;
+		$form = new Nette\Application\UI\Form;
 		$form->addText('count', 'Počet zboží:')
 			->addRule($form::FILLED)
 			->addRule($form::INTEGER);
@@ -51,7 +51,7 @@ Jediné, co zbývá, je zajistit, aby nám formulář do košíku přidal skute�
 protected function createComponentShopForm()
 {
 	return new Multiplier(function ($itemId) {
-		$form = new Form;
+		$form = new Nette\Application\UI\Form;
 		$form->addText('count', 'Počet zboží:')
 			->addRule($form::FILLED)
 			->addRule($form::INTEGER);

--- a/cs/multiplier.texy
+++ b/cs/multiplier.texy
@@ -15,7 +15,7 @@ Podstatou Multiplieru je, že vystupuje v pozici rodiče, který si své potomky
 protected function createComponentShopForm()
 {
 	return new Multiplier(function () {
-		$form = new Nette\Application\UI\Form;
+		$form = new Form;
 		$form->addText('count', 'Počet zboží:')
 			->addRule($form::FILLED)
 			->addRule($form::INTEGER);
@@ -51,7 +51,7 @@ Jediné, co zbývá, je zajistit, aby nám formulář do košíku přidal skute�
 protected function createComponentShopForm()
 {
 	return new Multiplier(function ($itemId) {
-		$form = new Nette\Application\UI\Form;
+		$form = new Form;
 		$form->addText('count', 'Počet zboží:')
 			->addRule($form::FILLED)
 			->addRule($form::INTEGER);

--- a/cs/pagination.texy
+++ b/cs/pagination.texy
@@ -209,6 +209,7 @@ use Nette;
 
 class ArticleRepository
 {
+	use Nette\SmartObject;
 
 	/** @var Nette\Database\Context */
 	private $database;
@@ -237,7 +238,6 @@ namespace App\Presenters;
 
 use Nette;
 use App\Model\ArticleRepository;
-
 
 class HomepagePresenter extends Nette\Application\UI\Presenter
 {

--- a/cs/pagination.texy
+++ b/cs/pagination.texy
@@ -9,12 +9,9 @@ Pamatuj, že Paginator pomůže jen s matematikou; Výběr části dat, jejich z
 Vyjdeme ze stavu, kdy vypisujeme všechna data bez stránkování. Pro výběr dat z databáze máme třídu ArticleRepository, která kromě konstruktoru obsahuje metodu `findPublishedArticles`, která vrací všechny publikované články seřazené sestupně podle data publikace.
 
 /--php
-<?php
-
 namespace App\Model;
 
 use Nette;
-
 
 class ArticleRepository
 {
@@ -23,14 +20,12 @@ class ArticleRepository
 	/** @var Nette\Database\Connection */
 	private $database;
 
-
 	public function __construct(Nette\Database\Connection $database)
 	{
 		$this->database = $database;
 	}
 
-
-	public function findPublishedArticles(): \Nette\Database\ResultSet
+	public function findPublishedArticles()
 	{
 		return $this->database->query('
 			SELECT * FROM articles
@@ -45,19 +40,20 @@ class ArticleRepository
 V presenteru si pak injectujeme modelovou třídu a v render metodě si vyžádáme publikované články, které předáme do šablony:
 
 /--php
-<?php
-
 namespace App\Presenters;
 
 use Nette;
 use App\Model\ArticleRepository;
 
-
 class HomepagePresenter extends Nette\Application\UI\Presenter
 {
-	/** @var ArticleRepository @inject */
-	public $articleRepository;
+	/** @var ArticleRepository */
+	private $articleRepository;
 
+	public function __construct(ArticleRepository $articleRepository)
+	{
+		$this->articleRepository = $articleRepository;
+	}
 
 	public function renderDefault()
 	{
@@ -88,12 +84,9 @@ Ten zajistí, že se všechny články rozdělí do několika stránek a my zobr
 V prvním kroku si upravíme metodu pro získání článků ve třídě repositáře tak, aby nám uměla vracet jen články pro jednu stránku. Také přidáme metodu pro zjištění celkového počtu článku v databázi, kterou budeme potřebovat pro nastavení Paginatoru:
 
 /--php
-<?php
-
 namespace App\Model;
 
 use Nette;
-
 
 class ArticleRepository
 {
@@ -102,14 +95,12 @@ class ArticleRepository
 	/** @var Nette\Database\Connection */
 	private $database;
 
-
 	public function __construct(Nette\Database\Connection $database)
 	{
 		$this->database = $database;
 	}
 
-
-	public function findPublishedArticles(int $limit, int $offset): \Nette\Database\ResultSet
+	public function findPublishedArticles($limit, $offset)
 	{
 		return $this->database->query('
 			SELECT * FROM articles
@@ -124,7 +115,7 @@ class ArticleRepository
 	/**
 	 * Vrací celkový počet publikovaných článků
 	 */
-	public function getPublishedArticlesCount(): int
+	public function getPublishedArticlesCount()
 	{
 		return $this->database->fetchField('SELECT COUNT(*) FROM articles WHERE created_at < ?', new \DateTime);
 	}
@@ -136,8 +127,6 @@ Následně se pustíme do úprav presenteru. Do render metody budeme předávat 
 Dále také render metodu rozšíříme o získání instance Paginatoru, jeho nastavení a výběru správných článků pro zobrazení v šabloně. HomepagePresenter bude po úpravách vypadat takto:
 
 /--php
-<?php
-
 namespace App\Presenters;
 
 use Nette;
@@ -146,9 +135,13 @@ use App\Model\ArticleRepository;
 
 class HomepagePresenter extends Nette\Application\UI\Presenter
 {
-	/** @var ArticleRepository @inject */
-	public $articleRepository;
+	/** @var ArticleRepository */
+	private $articleRepository;
 
+	public function __construct(ArticleRepository $articleRepository)
+	{
+		$this->articleRepository = $articleRepository;
+	}
 
 	public function renderDefault(int $page = 1)
 	{
@@ -210,16 +203,12 @@ Takto jsme doplnili stránku o možnost stránkování pomocí Paginatoru. V př
 Repozitář bude při tomto způsobu implementace vypadat takto:
 
 /--php
-<?php
-
 namespace App\Model;
 
 use Nette;
 
-
 class ArticleRepository
 {
-	use Nette\SmartObject;
 
 	/** @var Nette\Database\Context */
 	private $database;
@@ -231,7 +220,7 @@ class ArticleRepository
 	}
 
 
-	public function findPublishedArticles(): \Nette\Database\Table\Selection
+	public function findPublishedArticles()
 	{
 		return $this->database->table('articles')
 			->where('created_at < ', new \DateTime)
@@ -244,8 +233,6 @@ class ArticleRepository
 V presenteru nemusíme vytvářet Paginator, použijeme místo něj metodu třídy `Selection`, kterou nám vrací repositář:
 
 /--php
-<?php
-
 namespace App\Presenters;
 
 use Nette;
@@ -254,9 +241,13 @@ use App\Model\ArticleRepository;
 
 class HomepagePresenter extends Nette\Application\UI\Presenter
 {
-	/** @var ArticleRepository @inject */
-	public $articleRepository;
+	/** @var ArticleRepository */
+	private $articleRepository;
 
+	public function __construct(ArticleRepository $articleRepository)
+	{
+		$this->articleRepository = $articleRepository;
+	}
 
 	public function renderDefault(int $page = 1)
 	{

--- a/cs/presenters.texy
+++ b/cs/presenters.texy
@@ -519,7 +519,7 @@ Jde o zprávy obvykle informující o výsledku nějaké operace. Důležitým r
 Stačí zavolat metodu [flashMessage() |api:Nette\Application\UI\Control::flashMessage()] a o předání do šablony se postará presenter. Prvním parametrem je text zprávy a nepovinným druhým parametrem její typ (error, warning, info apod.). Metoda `flashMessage()` vrací instanci flash zprávy, které je možné přidávat další informace.
 
 /--php
-public function deleteFormSubmitted(Nette\Application\UI\Form $form, stdClass $values)
+public function deleteFormSubmitted()
 {
 	// ... požádáme model o smazání záznamu ...
 

--- a/cs/presenters.texy
+++ b/cs/presenters.texy
@@ -519,7 +519,7 @@ Jde o zprávy obvykle informující o výsledku nějaké operace. Důležitým r
 Stačí zavolat metodu [flashMessage() |api:Nette\Application\UI\Control::flashMessage()] a o předání do šablony se postará presenter. Prvním parametrem je text zprávy a nepovinným druhým parametrem její typ (error, warning, info apod.). Metoda `flashMessage()` vrací instanci flash zprávy, které je možné přidávat další informace.
 
 /--php
-public function deleteFormSubmitted(Nette\Application\UI\Form $form, Nette\Utils\ArrayHash $values)
+public function deleteFormSubmitted(Nette\Application\UI\Form $form, stdClass $values)
 {
 	// ... požádáme model o smazání záznamu ...
 

--- a/cs/presenters.texy
+++ b/cs/presenters.texy
@@ -101,7 +101,7 @@ class ProductPresenter extends Nette\Application\UI\Presenter
 	public function renderShow($id)
 	{
 		// získáme data z modelu a předáme do šablony
-		$this->template->product = $this->model->getProduct($id);
+		$this->template->product = $this->productRepository->getProduct($id);
 	}
 }
 \--
@@ -186,7 +186,7 @@ Pokud by součástí modulu `Front` byl presenter `Product`. Akce `show` se pak 
 /--php
 namespace FrontModule;
 
-class ProductPresenter extends \Nette\Application\UI\Presenter
+class ProductPresenter extends Nette\Application\UI\Presenter
 {
 	// ...
 }
@@ -337,7 +337,7 @@ Krom klasických parametrů, které jsme používali nyní, existují i tzv. per
 Pokud má vaše aplikace dvě jazykové mutace, bylo by neskutečně únavné v každém odkazu přenášet i aktuální jazyk. To není s Nette Framework potřeba. Prostě si parametr `$lang` označíme jako persistentní a to tímto způsobem:
 
 /--php
-class ProductPresenter extends Presenter
+class ProductPresenter extends Nette\Application\UI\Presenter
 {
 	/** @persistent */
 	public $lang;
@@ -499,7 +499,7 @@ Pokud nemůžeme splnit požadavek z důvodu, že například záznam neexistuje
 /--php
 public function renderShow($id)
 {
-	$product = $this->model->getProduct($id);
+	$product = $this->productRepository->getProduct($id);
 	if (!$product) {
 		$this->error();
 	}
@@ -519,7 +519,7 @@ Jde o zprávy obvykle informující o výsledku nějaké operace. Důležitým r
 Stačí zavolat metodu [flashMessage() |api:Nette\Application\UI\Control::flashMessage()] a o předání do šablony se postará presenter. Prvním parametrem je text zprávy a nepovinným druhým parametrem její typ (error, warning, info apod.). Metoda `flashMessage()` vrací instanci flash zprávy, které je možné přidávat další informace.
 
 /--php
-public function deleteFormSubmitted($form)
+public function deleteFormSubmitted(Nette\Application\UI\Form $form, Nette\Utils\ArrayHash $values)
 {
 	// ... požádáme model o smazání záznamu ...
 
@@ -545,10 +545,10 @@ Použití modelových tříd
 Jak jsme si řekli, model je samostatná vrstva a je složen z hromady tříd, kde každá obstarává část logiky aplikace. Pokud bychom měli například model `App\Articles`, který se stará o načítání a ukládání článků, mohli bychom si o něj v presenteru říct pomocí [Dependency Injection |dependency-injection], za předpokladu že je [registrovaný jako služba |configuring#sluzby] v [DI kontejneru |dependency-injection#nette-di-container].
 
 /--php
-class ArticlePresenter extends Presenter
+class ArticlePresenter extends Nette\Application\UI\Presenter
 {
-	/** @var \App\Articles @inject */
-	public $articles;
+	/** @var Articles @inject */
+	public $articleModel;
 
 	public function renderShow($id)
 	{
@@ -641,7 +641,7 @@ Nejen parametry, ale také komponenty mohou být persistentní. Jejich stav se p
 /**
  * @persistent(calendar, menu)
  */
-class DefaultPresenter extends Presenter
+class DefaultPresenter extends Nette\Application\UI\Presenter
 {
 	// ...
 }

--- a/cs/quickstart/authentication.texy
+++ b/cs/quickstart/authentication.texy
@@ -33,8 +33,6 @@ Nyní máme autentifikaci připravenu a musíme připravit uživatelské rozhran
 Začneme s přihlašovacím formulářem. Již víme jak formuláře v presenterech fungují. Vytvoříme si tedy presenter `SignPresenter` a zapíšeme metodu `createComponentSignInForm`. Měl by vypadat nějak takto:
 
 /--php
-<?php
-
 namespace App\Presenters;
 
 use Nette;
@@ -84,7 +82,7 @@ Dále doplníme callback pro přihlášení uživatele, který bude volán hned 
 Callback pouze převezme uživatelské jméno a heslo, které uživatel vyplnil a předá to authenticatoru. Po přihlášení přesměrujeme na úvodní stránku.
 
 /--php
-	public function signInFormSucceeded(Form $form, Nette\Utils\ArrayHash $values)
+	public function signInFormSucceeded(Form $form, stdClass $values)
 	{
 		try {
 			$this->getUser()->login($values->username, $values->password);
@@ -161,7 +159,7 @@ Poslední a **nejdůležitější věc** je **zabezpečit callbacky formulářů
 Tomu můžeme zabránit přidáním jednoduchého *if*, který přidáme na začátek metody `postFormSucceeded`:
 
 /--php
-	public function postFormSucceeded($form)
+	public function postFormSucceeded(Form $form, stdClass $values)
 	{
 		if (!$this->getUser()->isLoggedIn()) {
 			$this->error('Pro vytvoření, nebo editování příspěvku se musíte přihlásit.');

--- a/cs/quickstart/comments.texy
+++ b/cs/quickstart/comments.texy
@@ -92,7 +92,7 @@ $form->onSuccess[] = [$this, 'commentFormSucceeded'];
 Předchozí zápis znamená "po úspěšném odeslání formuláře zavolej metodu `commentFormSucceeded` ze současného presenteru". Tato metoda však ještě neexistuje, pojďme ji tedy vytvořit.
 
 /--php
-	public function commentFormSucceeded($form, $values)
+	public function commentFormSucceeded(Form $form, stdClass $values)
 	{
 		$postId = $this->getParameter('postId');
 

--- a/cs/quickstart/creating-posts.texy
+++ b/cs/quickstart/creating-posts.texy
@@ -78,7 +78,7 @@ Ukládání nového příspěvku z formuláře
 Pokračujeme přidáním metody, která zpracuje data z formuláře:
 
 /--php
-	public function postFormSucceeded($form, $values)
+	public function postFormSucceeded(Form $form, stdClass $values)
 	{
 		$post = $this->database->table('posts')->insert($values);
 
@@ -122,7 +122,7 @@ Nyní vytvoříme další šablonu (`app/presenters/templates/Post/edit.latte`):
 Rozšíříme také callback metodu:
 
 /--php
-	public function postFormSucceeded($form, $values)
+	public function postFormSucceeded(Form $form, stdClass $values)
 	{
 		$postId = $this->getParameter('postId');
 

--- a/cs/quickstart/home-page.texy
+++ b/cs/quickstart/home-page.texy
@@ -89,8 +89,6 @@ Předání databázového spojení
 Presenter (soubor `app/presenters/HomepagePresenter.php`), který se bude starat o výpis článků, potřebuje připojení k databázi. Pro jeho získání využijeme konstruktor, který bude vypadat takto:
 
 /--php
-<?php
-
 namespace App\Presenters;
 
 use Nette;

--- a/cs/quickstart/refactoring-model.texy
+++ b/cs/quickstart/refactoring-model.texy
@@ -12,8 +12,6 @@ V adresáři `app/model/` vytvoříme naši modelovou třídu `ArticleManager`, 
 
 
 /--php
-<?php
-
 namespace App\Model;
 
 use Nette;
@@ -22,9 +20,7 @@ class ArticleManager
 {
 	use Nette\SmartObject;
 
-	/**
-	 * @var Nette\Database\Context
-	 */
+	/** @var Nette\Database\Context */
 	private $database;
 
 	public function __construct(Nette\Database\Context $database)
@@ -80,13 +76,10 @@ Přepneme se do `HomepagePresenter.php`, který upravíme tak, že se zbavíme z
 
 
 /--php
-<?php
-
 namespace App\Presenters;
 
 use Nette;
 use App\Model\ArticleManager;
-
 
 class HomepagePresenter extends Nette\Application\UI\Presenter
 {

--- a/cs/quickstart/single-post.texy
+++ b/cs/quickstart/single-post.texy
@@ -10,7 +10,6 @@ Musíme si vytvořit novou render metodu, která získá jeden konkrétní člá
 `PostPresenter` by mohl tedy vypadat takto:
 
 /--php
-<?php
 namespace App\Presenters;
 
 use Nette;

--- a/cs/routing.texy
+++ b/cs/routing.texy
@@ -463,7 +463,6 @@ Router Factory
 Doporučenou cestou pro konfiguraci rout aplikace je si napsat továrnu (například třídu `RouterFactory`) a zaregistrovat ji do [systémového DI containeru |configuring#sluzby] v konfiguračním souboru:
 
 /--php
-<?php
 namespace App;
 
 use Nette;
@@ -538,7 +537,7 @@ Pokud máme více rout, které chceme zařadit do modulu, můžeme využít `Rou
 class RouterFactory
 {
 	/**
-	 * @return \Nette\Application\IRouter
+	 * @return Nette\Application\IRouter
 	 */
 	public static function createRouter()
 	{
@@ -603,12 +602,12 @@ use Nette\Http\Url;
 
 class MyRouter implements Nette\Application\IRouter
 {
-	function match(HttpRequest $httpRequest)
+	public function match(HttpRequest $httpRequest)
 	{
 		// ...
 	}
 
-	function constructUrl(AppRequest $appRequest, Url $refUrl)
+	public function constructUrl(AppRequest $appRequest, Url $refUrl)
 	{
 		// ...
 	}

--- a/en/access-control.texy
+++ b/en/access-control.texy
@@ -103,18 +103,16 @@ Custom Authenticator
 We will create a custom authenticator that will check validity of login credentials against a database table. Every authenticator must be an implementation of [api:Nette\Security\IAuthenticator], with its only method `authenticate()`. Its only purpose is to return an [identity |#identity] or to throw an `Nette\Security\AuthenticationException`. Framework defines few error codes, that can be used to determine the reason login was not successful, such as self-explaining `IAuthenticator::IDENTITY_NOT_FOUND` or `IAuthenticator::INVALID_CREDENTIAL`.
 
 /--php
-use Nette\Security as NS;
-
-class MyAuthenticator implements NS\IAuthenticator
+class MyAuthenticator implements Nette\Security\IAuthenticator
 {
-	public $database;
+	private $database;
 
-	function __construct(Nette\Database\Connection $database)
+	public function __construct(Nette\Database\Connection $database)
 	{
 		$this->database = $database;
 	}
 
-	function authenticate(array $credentials)
+	public function authenticate(array $credentials)
 	{
 		list($username, $password) = $credentials;
 		$row = $this->database->table('users')
@@ -128,7 +126,7 @@ class MyAuthenticator implements NS\IAuthenticator
 			throw new NS\AuthenticationException('Invalid password.');
 		}
 
-		return new NS\Identity($row->id, $row->role, ['username' => $row->username]);
+		return new Nette\Security\Identity($row->id, $row->role, ['username' => $row->username]);
 	}
 }
 \--
@@ -218,7 +216,7 @@ An implementation skeleton looks like this:
 /--php
 class MyAuthorizator implements Nette\Security\IAuthorizator
 {
-	function isAllowed($role, $resource, $privilege)
+	public function isAllowed($role, $resource, $privilege)
 	{
 		return ...; // returns either true or false
 	}
@@ -426,8 +424,6 @@ and then we can verify privileges in Presenter e.g. in the startup method:
 Following solution is alternative to the previous one. We create factory service, where we can setup Permission:
 
 /--php
-<?php
-
 namespace App\Model;
 
 class AuthorizatorFactory
@@ -502,8 +498,13 @@ services:
 /--php
 class SignPresenter extends Nette\Application\UI\Presenter
 {
-	/** @var FrontAuthenticator @inject */
-	public $authenticator;
+	/** @var FrontAuthenticator */
+	private $authenticator;
+
+	public function __construct(FrontAuthenticator $authenticator)
+	{
+		$this->authenticator = $authenticator;
+	}
 }
 \--
 

--- a/en/access-control.texy
+++ b/en/access-control.texy
@@ -103,7 +103,9 @@ Custom Authenticator
 We will create a custom authenticator that will check validity of login credentials against a database table. Every authenticator must be an implementation of [api:Nette\Security\IAuthenticator], with its only method `authenticate()`. Its only purpose is to return an [identity |#identity] or to throw an `Nette\Security\AuthenticationException`. Framework defines few error codes, that can be used to determine the reason login was not successful, such as self-explaining `IAuthenticator::IDENTITY_NOT_FOUND` or `IAuthenticator::INVALID_CREDENTIAL`.
 
 /--php
-class MyAuthenticator implements Nette\Security\IAuthenticator
+use Nette\Security as NS;
+
+class MyAuthenticator implements NS\IAuthenticator
 {
 	private $database;
 

--- a/en/ajax.texy
+++ b/en/ajax.texy
@@ -120,7 +120,7 @@ You can't invalidate dynamic snippet directly (invalidation of `item-1` takes no
 In the example above, you have to make sure, that for an AJAX request only one item will be added to the `$list` array, therefore the `foreach` loop will print just one dynamic snippet.
 
 /--php
-class HomepagePresenter extends \Nette\Application\UI\Presenter
+class HomepagePresenter extends Nette\Application\UI\Presenter
 {
 	/**
 	 * This method returns data for the list.

--- a/en/caching.texy
+++ b/en/caching.texy
@@ -262,11 +262,13 @@ use Nette;
 
 class MyPresenter
 {
-	/**
-	 * @inject
-	 * @var Nette\Caching\IStorage
-	 */
-	public $storage;
+	/** @var Nette\Caching\IStorage */
+	private $storage;
+
+	public function __construct(Nette\Caching\IStorage $storage)
+	{
+		$this->storage = $storage;
+	}
 
 	public function actionDefault()
 	{

--- a/en/components.texy
+++ b/en/components.texy
@@ -86,7 +86,7 @@ Sending is done by the method [flashMessage |api:Nette\Application\UI\Control::f
 Example:
 
 /--php
-public function deleteFormSubmitted(Nette\Application\UI\Form $form, Nette\Utils\ArrayHash $values)
+public function deleteFormSubmitted(Nette\Application\UI\Form $form, stdClass $values)
 {
 	... delete record using model ...
 

--- a/en/components.texy
+++ b/en/components.texy
@@ -36,12 +36,10 @@ A component has factory for its [template |latte:]. It creates a template, passe
 /--php
 public function render()
 {
-	$template = $this->template;
-	$template->setFile(__DIR__ . '/poll.latte');
 	// insert some parameters to the template
 	$template->param = 'some value';
 	// render it
-	$template->render();
+	$this->template->render(__DIR__ . '/poll.latte');
 }
 \--
 
@@ -88,7 +86,7 @@ Sending is done by the method [flashMessage |api:Nette\Application\UI\Control::f
 Example:
 
 /--php
-public function deleteFormSubmitted(Form $form)
+public function deleteFormSubmitted(Nette\Application\UI\Form $form, Nette\Utils\ArrayHash $values)
 {
 	... delete record using model ...
 
@@ -238,9 +236,7 @@ OK, but how is the `PollManager` put into the `PollControl`'s constructor? To do
 /--php
 class PollControlFactory
 {
-	/**
-	 * @var PollManager
-	 */
+	/** @var PollManager */
 	private $pollManager;
 
 	public function __construct(PollManager $pollManager)
@@ -267,11 +263,9 @@ services:
 Finally, we will use this factory in our presenter:
 
 /--php
-class PollPresenter extends \Nette\UI\Application\Presenter
+class PollPresenter extends Nette\UI\Application\Presenter
 {
-	/**
-	 * @var PollControlFactory
-	 */
+	/** @var PollControlFactory */
 	private $pollControlFactory;
 
 	public function __construct(PollControlFactory $pollControlFactory)

--- a/en/composer.texy
+++ b/en/composer.texy
@@ -119,7 +119,7 @@ The simplest `composer.json` can look like this:
 }
 \--
 
-We're saying here, that our application (or library) depends on package `nette/nette` and it wants the newest version, that matches the `~2.4.0` version constraint and also that it will only run on PHP higher or equal to `5.6.1`. We suggest to use latest PHP 7.2.
+We're saying here, that our application (or library) depends on package `nette/nette` and it wants the newest version, that matches the `~2.4.0` version constraint and also that it will only run on PHP higher or equal to `5.6.1`.
 
 So, when we have the `composer.json` file in the project root and we run
 

--- a/en/composer.texy
+++ b/en/composer.texy
@@ -119,7 +119,7 @@ The simplest `composer.json` can look like this:
 }
 \--
 
-We're saying here, that our application (or library) depends on package `nette/nette` and it wants the newest version, that matches the `~2.4.0` version constraint and also that it will only run on PHP higher or equal to `5.6.1`.
+We're saying here, that our application (or library) depends on package `nette/nette` and it wants the newest version, that matches the `~2.4.0` version constraint and also that it will only run on PHP higher or equal to `5.6.1`. We suggest to use latest PHP 7.2.
 
 So, when we have the `composer.json` file in the project root and we run
 

--- a/en/database-core.texy
+++ b/en/database-core.texy
@@ -28,7 +28,7 @@ However, a more sophisticated way offers [application configuration |configuring
 The connection object we [receive as a service from a DI container |di-usage], for example:
 
 /--php
-class Model
+class FooModel
 {
 	private $database;
 

--- a/en/di-configuration.texy
+++ b/en/di-configuration.texy
@@ -355,7 +355,7 @@ class ArticleRepository
 	public function __construct(\PDO $db)
 	{}
 
-	public function setCacheStorage(\Nette\Caching\IStorage $storage)
+	public function setCacheStorage(Nette\Caching\IStorage $storage)
 	{}
 }
 \--

--- a/en/di-configuration.texy
+++ b/en/di-configuration.texy
@@ -352,7 +352,7 @@ namespace Model;
 
 class ArticleRepository
 {
-	public function __construct(\PDO $db)
+	public function __construct(PDO $db)
 	{}
 
 	public function setCacheStorage(Nette\Caching\IStorage $storage)

--- a/en/di-usage.texy
+++ b/en/di-usage.texy
@@ -432,7 +432,7 @@ In the presenter, we only have to obtain the factory instance and call the `crea
 /--php
 class UserPresenter extends Nette\Application\UI\Presenter
 {
-	/** @var IUserTableFactory @inject */
+	/** @var \App\Components\IUserTableFactory @inject */
 	public $userTableFactory;
 
 	protected function createComponentUserTable()

--- a/en/di-usage.texy
+++ b/en/di-usage.texy
@@ -107,7 +107,7 @@ Second method specific for Nette Framework. It is a special case of passing by a
 /--php
 class MyService
 {
-	/** @var \App\AnotherService @inject */
+	/** @var AnotherService @inject */
 	public $anotherService;
 }
 \--
@@ -158,7 +158,7 @@ class MyPresenter extends Nette\Application\UI\Presenter
 	}
 
 	// 3) Public variable with the @inject annotation:
-	/** @var \App\Service3 @inject */
+	/** @var Service3 @inject */
 	public $service3;
 }
 \--
@@ -203,10 +203,10 @@ The component could be used in the presenter in the following way:
 /--php
 class MyPresenter extends Nette\Application\UI\Presenter
 {
-	/** @var \App\Service1 @inject */
+	/** @var Service1 @inject */
 	public $service1;
 
-	/** @var \App\Service2 @inject */
+	/** @var Service2 @inject */
 	public $service2;
 
 	protected function createComponentMyControl()
@@ -329,7 +329,7 @@ class Service3
 	}
 
 	// 2) Assign to the variable with the @inject annotation:
-	/** @var \App\Service2 @inject */
+	/** @var Service2 @inject */
 	public $service2;
 }
 \--
@@ -432,7 +432,7 @@ In the presenter, we only have to obtain the factory instance and call the `crea
 /--php
 class UserPresenter extends Nette\Application\UI\Presenter
 {
-	/** @var \App\Components\IUserTableFactory @inject */
+	/** @var IUserTableFactory @inject */
 	public $userTableFactory;
 
 	protected function createComponentUserTable()

--- a/en/form-rendering.texy
+++ b/en/form-rendering.texy
@@ -124,7 +124,7 @@ You can render forms manually for better control over the generated code. Place 
 You can also connect a form with a template easily by using `n:name` attribute.
 
 /--php
-function createComponentSignInForm()
+protected function createComponentSignInForm()
 {
 	$form = new Form;
 	$form->addText('user')->setRequired();

--- a/en/forms.texy
+++ b/en/forms.texy
@@ -20,6 +20,8 @@ First Form
 Let's create a simple registration form for our app. Forms are added into presenters using component [factories |presenters#component-factories]:
 
 /--php
+use Nette\Application\UI;
+
 class HomepagePresenter extends Nette\Application\UI\Presenter
 {
 	// ...

--- a/en/forms.texy
+++ b/en/forms.texy
@@ -20,9 +20,7 @@ First Form
 Let's create a simple registration form for our app. Forms are added into presenters using component [factories |presenters#component-factories]:
 
 /--php
-use Nette\Application\UI;
-
-class HomepagePresenter extends UI\Presenter
+class HomepagePresenter extends Nette\Application\UI\Presenter
 {
 	// ...
 
@@ -37,7 +35,7 @@ class HomepagePresenter extends UI\Presenter
 	}
 
 	// called after form is successfully submitted
-	public function registrationFormSucceeded(UI\Form $form, $values)
+	public function registrationFormSucceeded(UI\Form $form, stdClass $values)
 	{
 		// ...
 		$this->flashMessage('You have successfully signed up.');
@@ -305,9 +303,6 @@ use Nette\Application\UI\Form;
 
 class SignInFormFactory
 {
-	/**
-	 * @return Form
-	 */
 	public function create()
 	{
 		$form = new Form;
@@ -351,7 +346,7 @@ class SignInFormFactory
 		...
 		$form->addSubmit('login', 'Log in');
 
-		$form->onSuccess[] = function (Form $form, \stdClass $values) {
+		$form->onSuccess[] = function (Nette\Application\UI\Form $form, Nette\Utils\ArrayHash $values) {
 			// we process our submitted form here
 		};
 

--- a/en/localization.texy
+++ b/en/localization.texy
@@ -54,11 +54,11 @@ Template Translation
 Translator can also be set for [templates|latte:]. Again, by using the `setTranslator()` method, for example in presenter:
 
 /--php
-	function beforeRender()
-	{
-		...
-		$this->template->setTranslator($translator);
-	}
+protected function beforeRender()
+{
+	...
+	$this->template->setTranslator($translator);
+}
 \--
 
 After this, all expressions within the [localization macros|latte:macros#localization] will be translated:

--- a/en/migration-2-1.texy
+++ b/en/migration-2-1.texy
@@ -127,7 +127,7 @@ Database (NDB)
 Are you using Nette Database Table (NDBT), a great part of the NDB to which is accessed via `$database->table(...)`?
 
 - method `table()` was moved from `Connection` to new class `Nette\Database\Context`. It "contains":https://api.nette.org/2.1/Nette.Database.Context.html all of the important methods for working with databases, so feel free to change the `Connection` for `Context` and you're done.
-- properties of `ActiveRow` are now read-only, for updating use `$row->update(array('field' => 'value'))`. The old behavior had so many difficulties, sorry.
+- properties of `ActiveRow` are now read-only, for updating use `$row->update(['field' => 'value'])`. The old behavior had so many difficulties, sorry.
 - backjoin syntax was changed from `book_tag:tag.name` to `:book_tag.tag.name` (see semicolons)
 - instead of second argument `$having` in method `group()` use method `having()`
 - Selection: removed support for INNER join in where statement ("commit":https://github.com/nette/nette/commit/68314840e2429351d1e37e00c6070a21bdc36744)

--- a/en/multiplier.texy
+++ b/en/multiplier.texy
@@ -15,7 +15,7 @@ Multiplier poses as a parent component which can dynamically create its children
 protected function createComponentShopForm()
 {
 	return new Multiplier(function () {
-		$form = new Form;
+		$form = new Nette\Application\UI\Form;
 		$form->addText('amount', 'Amount:')
 			->addRule($form::FILLED)
 			->addRule($form::INTEGER);
@@ -51,7 +51,7 @@ The last thing is to ensure that the form actually adds the correct product to t
 protected function createComponentShopForm()
 {
 	return new Multiplier(function ($itemId) {
-		$form = new Form;
+		$form = new Nette\Application\UI\Form;
 		$form->addText('amount', 'Amount:')
 			->addRule($form::FILLED)
 			->addRule($form::INTEGER);

--- a/en/multiplier.texy
+++ b/en/multiplier.texy
@@ -15,7 +15,7 @@ Multiplier poses as a parent component which can dynamically create its children
 protected function createComponentShopForm()
 {
 	return new Multiplier(function () {
-		$form = new Nette\Application\UI\Form;
+		$form = new Form;
 		$form->addText('amount', 'Amount:')
 			->addRule($form::FILLED)
 			->addRule($form::INTEGER);
@@ -51,7 +51,7 @@ The last thing is to ensure that the form actually adds the correct product to t
 protected function createComponentShopForm()
 {
 	return new Multiplier(function ($itemId) {
-		$form = new Nette\Application\UI\Form;
+		$form = new Form;
 		$form->addText('amount', 'Amount:')
 			->addRule($form::FILLED)
 			->addRule($form::INTEGER);

--- a/en/pagination.texy
+++ b/en/pagination.texy
@@ -9,8 +9,6 @@ Remember that Paginator will only help math; Selecting a portion of the data, di
 We come out of the state when we list all the data without paging. To select data from the database, we have the ArticleRepository class, which contains the constructor and the `findPublishedArticles` method, which returns all published articles sorted in descending order of publication date.
 
 /--php
-<?php
-
 namespace App\Model;
 
 use Nette;
@@ -30,7 +28,7 @@ class ArticleRepository
 	}
 
 
-	public function findPublishedArticles(): \Nette\Database\ResultSet
+	public function findPublishedArticles()
 	{
 		return $this->database->query('
 			SELECT * FROM articles
@@ -45,8 +43,6 @@ class ArticleRepository
 In the Presenter we then inject the model class and in the render method we will ask for the published articles that we pass to the template:
 
 /--php
-<?php
-
 namespace App\Presenters;
 
 use Nette;
@@ -55,9 +51,13 @@ use App\Model\ArticleRepository;
 
 class HomepagePresenter extends Nette\Application\UI\Presenter
 {
-	/** @var ArticleRepository @inject */
-	public $articleRepository;
+	/** @var ArticleRepository */
+	private $articleRepository;
 
+	public function __construct(ArticleRepository $articleRepository)
+	{
+		$this->articleRepository = $articleRepository;
+	}
 
 	public function renderDefault()
 	{
@@ -88,12 +88,9 @@ This will ensure that all articles are split into several pages and we will only
 In the first step, we will modify the method for getting articles in the repository class to return only single-page articles. We will also add a new method to get the total number of articles in the database, which we will need to set a Paginator:
 
 /--php
-<?php
-
 namespace App\Model;
 
 use Nette;
-
 
 class ArticleRepository
 {
@@ -102,14 +99,12 @@ class ArticleRepository
 	/** @var Nette\Database\Connection */
 	private $database;
 
-
 	public function __construct(Nette\Database\Connection $database)
 	{
 		$this->database = $database;
 	}
 
-
-	public function findPublishedArticles(int $limit, int $offset): \Nette\Database\ResultSet
+	public function findPublishedArticles($limit, $offset)
 	{
 		return $this->database->query('
 			SELECT * FROM articles
@@ -124,7 +119,7 @@ class ArticleRepository
 	/**
 	 * Returns the total number of published articles
 	 */
-	public function getPublishedArticlesCount(): int
+	public function getPublishedArticlesCount()
 	{
 		return $this->database->fetchField('SELECT COUNT(*) FROM articles WHERE created_at < ?', new \DateTime);
 	}
@@ -136,8 +131,6 @@ The next step is to edit the presenter. We will forward the number of the curren
 We also expand the render method to get the Paginator instance, setting it up, and selecting the correct articles to display in the template. HomepagePresenter will look like this:
 
 /--php
-<?php
-
 namespace App\Presenters;
 
 use Nette;
@@ -146,11 +139,15 @@ use App\Model\ArticleRepository;
 
 class HomepagePresenter extends Nette\Application\UI\Presenter
 {
-	/** @var ArticleRepository @inject */
-	public $articleRepository;
+	/** @var ArticleRepository */
+	private $articleRepository;
 
+	public function __construct(ArticleRepository $articleRepository)
+	{
+		$this->articleRepository = $articleRepository;
+	}
 
-	public function renderDefault(int $page = 1)
+	public function renderDefault($page = 1)
 	{
 		// We'll find the total number of published articles
 		$articlesCount = $this->articleRepository->getPublishedArticlesCount();
@@ -210,8 +207,6 @@ This is how we've added pagination using Paginator. If [Nette Database Explorer 
 The repository will look like this:
 
 /--php
-<?php
-
 namespace App\Model;
 
 use Nette;
@@ -231,7 +226,7 @@ class ArticleRepository
 	}
 
 
-	public function findPublishedArticles(): \Nette\Database\Table\Selection
+	public function findPublishedArticles()
 	{
 		return $this->database->table('articles')
 			->where('created_at < ', new \DateTime)
@@ -243,8 +238,6 @@ class ArticleRepository
 We do not have to create Paginator in the Presenter, instead we will use the method of `Selection` object returned by the repository:
 
 /--php
-<?php
-
 namespace App\Presenters;
 
 use Nette;
@@ -253,11 +246,15 @@ use App\Model\ArticleRepository;
 
 class HomepagePresenter extends Nette\Application\UI\Presenter
 {
-	/** @var ArticleRepository @inject */
-	public $articleRepository;
+	/** @var ArticleRepository */
+	private $articleRepository;
 
+	public function __construct(ArticleRepository $articleRepository)
+	{
+		$this->articleRepository = $articleRepository;
+	}
 
-	public function renderDefault(int $page = 1)
+	public function renderDefault($page = 1)
 	{
 		// We'll find published articles
 		$articles = $this->articleRepository->findPublishedArticles();

--- a/en/pagination.texy
+++ b/en/pagination.texy
@@ -211,7 +211,6 @@ namespace App\Model;
 
 use Nette;
 
-
 class ArticleRepository
 {
 	use Nette\SmartObject;
@@ -242,7 +241,6 @@ namespace App\Presenters;
 
 use Nette;
 use App\Model\ArticleRepository;
-
 
 class HomepagePresenter extends Nette\Application\UI\Presenter
 {

--- a/en/presenters.texy
+++ b/en/presenters.texy
@@ -101,7 +101,7 @@ class ProductPresenter extends Nette\Application\UI\Presenter
 	public function renderShow($id)
 	{
 		// we will get data from model and pass it to template
-		$this->template->product = $this->model->getProduct($id);
+		$this->template->product = $this->productRepository->getProduct($id);
 	}
 }
 \--
@@ -186,7 +186,7 @@ If module `Front` would contain presenter `Product`. Action `show` can than be w
 /--php
 namespace FrontModule;
 
-class ProductPresenter extends \Nette\Application\UI\Presenter
+class ProductPresenter extends Nette\Application\UI\Presenter
 {
 	// ...
 }
@@ -337,7 +337,7 @@ Except classic parameters, that we know by now, there are so called persistent p
 When your application has multiple language variants passing the actual language in every link will be incredibly tiring. But that's not needed with Nette Framework. You can simply mark the `$lang` parameter as persistent just like this:
 
 /--php
-class ProductPresenter extends Presenter
+class ProductPresenter extends Nette\Application\UI\Presenter
 {
 	/** @persistent */
 	public $lang;
@@ -499,7 +499,7 @@ When we can't fulfill the request, because for example the record is missing in 
 /--php
 public function renderShow($id)
 {
-	$product = $this->model->getProduct($id);
+	$product = $this->productRepository->getProduct($id);
 	if (!$product) {
 		$this->error();
 	}
@@ -519,7 +519,7 @@ These are messages informing about a result of some operation. An important feat
 Just call the [flashMessage() |api:Nette\Application\UI\Control::flashMessage()] method and presenter will take care about passing the message to template. First argument is the text of the message and second optional argument is its type (error, warning, info etc.). The method `flashMessage()` returns an instance of flash message, to allow us to add more information.
 
 /--php
-public function deleteFormSubmitted($form)
+public function deleteFormSubmitted(Nette\Application\UI\Form $form, Nette\Utils\ArrayHash $values)
 {
 	// ... model asks for deletion of record ...
 
@@ -545,9 +545,9 @@ Usage of Model Classes
 As we've said before, model is a whole layer composed of many classes, where each one is taking care of one part of application logic. If we'd have for example a model `App\Articles`, which would take care of loading and saving articles, we may ask for it in a presenter using [Dependency Injection |dependency-injection], assuming we've [properly registered it as a service |configuring#services] in [DI Container |dependency-injection#nette-di-container].
 
 /--php
-class ArticlePresenter extends Presenter
+class ArticlePresenter extends Nette\Application\UI\Presenter
 {
-	/** @var \App\Articles @inject */
+	/** @var Articles @inject */
 	public $articles;
 
 	public function renderShow($id)
@@ -640,7 +640,7 @@ Not only parameters, but also components can be persistent. Their state is then 
 /**
  * @persistent(calendar, menu)
  */
-class DefaultPresenter extends Presenter
+class DefaultPresenter extends Nette\Application\UI\Presenter
 {
 	// ...
 }

--- a/en/presenters.texy
+++ b/en/presenters.texy
@@ -519,7 +519,7 @@ These are messages informing about a result of some operation. An important feat
 Just call the [flashMessage() |api:Nette\Application\UI\Control::flashMessage()] method and presenter will take care about passing the message to template. First argument is the text of the message and second optional argument is its type (error, warning, info etc.). The method `flashMessage()` returns an instance of flash message, to allow us to add more information.
 
 /--php
-public function deleteFormSubmitted(Nette\Application\UI\Form $form, stdClass $values)
+public function deleteFormSubmitted()
 {
 	// ... model asks for deletion of record ...
 

--- a/en/presenters.texy
+++ b/en/presenters.texy
@@ -519,7 +519,7 @@ These are messages informing about a result of some operation. An important feat
 Just call the [flashMessage() |api:Nette\Application\UI\Control::flashMessage()] method and presenter will take care about passing the message to template. First argument is the text of the message and second optional argument is its type (error, warning, info etc.). The method `flashMessage()` returns an instance of flash message, to allow us to add more information.
 
 /--php
-public function deleteFormSubmitted(Nette\Application\UI\Form $form, Nette\Utils\ArrayHash $values)
+public function deleteFormSubmitted(Nette\Application\UI\Form $form, stdClass $values)
 {
 	// ... model asks for deletion of record ...
 

--- a/en/quickstart/authentication.texy
+++ b/en/quickstart/authentication.texy
@@ -33,13 +33,7 @@ We now have the backend part of authentication ready and we need to provide a us
 Let's start with the login form. You already know how forms work in a presenter. Create the `SignPresenter` and method `createComponentSignInForm`. It should look like this:
 
 /--php
-<?php
-
 namespace App\Presenters;
-
-use Nette;
-use Nette\Application\UI\Form;
-
 
 class SignPresenter extends Nette\Application\UI\Presenter
 {
@@ -84,7 +78,7 @@ We add also a *form handler* for signing in the user, that gets invoked right af
 The handler will just take the username and password the user entered and will pass it to the authenticator defined earlier. After the user has logged in, we will redirect him to the homepage.
 
 /--php
-	public function signInFormSucceeded(Form $form, Nette\Utils\ArrayHash $values)
+	public function signInFormSucceeded(Form $form, stdClass $values)
 	{
 		try {
 			$this->getUser()->login($values->username, $values->password);
@@ -160,7 +154,7 @@ The last, and **the most important thing** is to **secure the form handler**. Be
 It can be prevented with a simple *if* that we will add at the beginning of `postFormSucceeded`
 
 /--php
-	public function postFormSucceeded($form)
+	public function signInFormSucceeded(Form $form, stdClass $values)
 	{
 		if (!$this->getUser()->isLoggedIn()) {
 			$this->error('You need to log in to create or edit posts');

--- a/en/quickstart/comments.texy
+++ b/en/quickstart/comments.texy
@@ -91,7 +91,7 @@ $form->onSuccess[] = [$this, 'commentFormSucceeded'];
 It means "after the form is successfully submitted, call the method `commentFormSucceeded` of the current presenter". This method does not exist yet, so let’s create it.
 
 /--php
-	public function commentFormSucceeded($form, $values)
+	public function commentFormSucceeded(Form $form, stdClass $values)
 	{
 		$postId = $this->getParameter('postId');
 

--- a/en/quickstart/creating-posts.texy
+++ b/en/quickstart/creating-posts.texy
@@ -78,7 +78,7 @@ Saving New Post from Form
 Continue by adding a handler method.
 
 /--php
-	public function postFormSucceeded($form, $values)
+	public function postFormSucceeded(Form $form, stdClass $values)
 	{
 		$post = $this->database->table('posts')->insert($values);
 
@@ -122,7 +122,7 @@ Now create the template (`app/presenters/templates/Post/edit.latte`):
 Let’s also extend the form handler:
 
 /--php
-	public function postFormSucceeded($form, $values)
+	public function postFormSucceeded(Form $form, stdClass $values)
 	{
 		$postId = $this->getParameter('postId');
 

--- a/en/quickstart/home-page.texy
+++ b/en/quickstart/home-page.texy
@@ -88,12 +88,10 @@ Injecting the Database Connection
 The presenter (located in `app/presenters/HomepagePresenter.php`), which will list the articles, needs a database connection. To receive it, write a constructor like this:
 
 /--php
-<?php
 
 namespace App\Presenters;
 
 use Nette;
-
 
 class HomepagePresenter extends Nette\Application\UI\Presenter
 {

--- a/en/quickstart/refactoring-model.texy
+++ b/en/quickstart/refactoring-model.texy
@@ -10,8 +10,6 @@ We'll place the function into the `ArticleManager` class and call it `getPublicA
 We'll create our model class `ArticleManager` in the directory `app/model/` to take care of our articles. Let's place it into the `ArticleManager.php` file.
 
 /--php
-<?php
-
 namespace App\Model;
 
 use Nette;
@@ -77,8 +75,6 @@ That way we tell Nette and its [DI container |/dependency-injection] the followi
 We will switch to `HomepagePresenter.php` which we will edit so that we get rid of the dependency on `Nette\Database\Context` replacing that with a new dependency on our new class.
 
 /--php
-<?php
-
 namespace App\Presenters;
 
 use Nette;

--- a/en/quickstart/single-post.texy
+++ b/en/quickstart/single-post.texy
@@ -10,7 +10,6 @@ We need to create a new render method, that will fetch one specific blog post an
 The `PostPresenter` should look like this:
 
 /--php
-<?php
 namespace App\Presenters;
 
 use Nette;

--- a/en/routing.texy
+++ b/en/routing.texy
@@ -465,7 +465,6 @@ Router Factory
 The recommended way to configure the application router is to write a factory (e.g. class `RouterFactory`) and register it to [system DI container |configuring#services] in a configuration file:
 
 /--php
-<?php
 namespace App;
 
 use Nette;
@@ -541,7 +540,7 @@ If we have more routes that we want to group together in a module, we can use `R
 class RouterFactory
 {
 	/**
-	 * @return \Nette\Application\IRouter
+	 * @return Nette\Application\IRouter
 	 */
 	public static function createRouter()
 	{
@@ -603,12 +602,12 @@ use Nette\Http\Url;
 
 class MyRouter implements Nette\Application\IRouter
 {
-	function match(HttpRequest $httpRequest)
+	public function match(HttpRequest $httpRequest)
 	{
 		// ...
 	}
 
-	function constructUrl(AppRequest $appRequest, Url $refUrl)
+	public function constructUrl(AppRequest $appRequest, Url $refUrl)
 	{
 		// ...
 	}

--- a/wip/book/cs/book/ajax.texy
+++ b/wip/book/cs/book/ajax.texy
@@ -141,7 +141,7 @@ Nyní by bylo vhodné upravit `TaskPresenter` tak, aby i přidávání úkolů p
 V metodě, která zpracovává odeslaný formulář, provedeme podobnou úpravu, jako u signálu v komponentě `TaskList`:
 
 /--php
-public function taskFormSubmitted(Form $form)
+public function taskFormSubmitted(Nette\Application\UI\Form $form, Nette\Utils\ArrayHash $values)
 {
 	$this->taskRepository->createTask($this->list->id, $form->values->text, $form->values->userId);
 	$this->flashMessage('Úkol přidán.', 'success');
@@ -180,7 +180,7 @@ Všechny komponenty se sice aktualizují, ale nezobrazují se nám flash zprávy
 Invalidaci můžeme provést v metodě `beforeRender()` v `BasePresenter`u:
 
 /--php
-public function beforeRender()
+protected function beforeRender()
 {
 	$this->template->lists = $this->listRepository->findAll()->order('title ASC');
 	if ($this->isAjax()) {

--- a/wip/book/cs/book/ajax.texy
+++ b/wip/book/cs/book/ajax.texy
@@ -141,7 +141,7 @@ Nyní by bylo vhodné upravit `TaskPresenter` tak, aby i přidávání úkolů p
 V metodě, která zpracovává odeslaný formulář, provedeme podobnou úpravu, jako u signálu v komponentě `TaskList`:
 
 /--php
-public function taskFormSubmitted(Nette\Application\UI\Form $form, Nette\Utils\ArrayHash $values)
+public function taskFormSubmitted(Nette\Application\UI\Form $form, stdClass $values)
 {
 	$this->taskRepository->createTask($this->list->id, $form->values->text, $form->values->userId);
 	$this->flashMessage('Úkol přidán.', 'success');

--- a/wip/book/cs/book/authentication.texy
+++ b/wip/book/cs/book/authentication.texy
@@ -82,7 +82,7 @@ protected function createComponentSignInForm()
 	return $form;
 }
 
-public function signInFormSubmitted(Form $form)
+public function signInFormSubmitted(Nette\Application\UI\Form $form, Nette\Utils\ArrayHash $values)
 {
 	try {
 		$user = $this->getUser();
@@ -265,7 +265,7 @@ Výpis úkolů uživatele
 S připravenými komponentami je nyní již výpis všech úkolů, které jsou přiřazené momentálně přihlášenému uživateli, triviální. Stačí jen vytvořit novou komponentu a vykreslit ji v šabloně. `HomepagePresenter`:
 
 /--php
-public function createComponentUserTasks()
+protected function createComponentUserTasks()
 {
 	$incomplete = $this->taskRepository->findIncompleteByUser($this->getUser()->getId());
 	$control = new Todo\TaskListControl($incomplete, $this->taskRepository);
@@ -361,7 +361,7 @@ class UserPresenter extends BasePresenter
 	}
 
 
-	public function passwordFormSubmitted(Form $form)
+	public function passwordFormSubmitted(Nette\Application\UI\Form $form, Nette\Utils\ArrayHash $values)
 	{
 		$values = $form->getValues();
 		$user = $this->getUser();

--- a/wip/book/cs/book/authentication.texy
+++ b/wip/book/cs/book/authentication.texy
@@ -82,7 +82,7 @@ protected function createComponentSignInForm()
 	return $form;
 }
 
-public function signInFormSubmitted(Nette\Application\UI\Form $form, Nette\Utils\ArrayHash $values)
+public function signInFormSubmitted(Nette\Application\UI\Form $form, stdClass $values)
 {
 	try {
 		$user = $this->getUser();
@@ -361,7 +361,7 @@ class UserPresenter extends BasePresenter
 	}
 
 
-	public function passwordFormSubmitted(Nette\Application\UI\Form $form, Nette\Utils\ArrayHash $values)
+	public function passwordFormSubmitted(Nette\Application\UI\Form $form, stdClass $values)
 	{
 		$values = $form->getValues();
 		$user = $this->getUser();

--- a/wip/book/cs/book/components.texy
+++ b/wip/book/cs/book/components.texy
@@ -20,7 +20,7 @@ use Nette;
 
 class TaskListControl extends Nette\Application\UI\Control
 {
-	/** @var \Nette\Database\Table\Selection */
+	/** @var Nette\Database\Table\Selection */
 	private $selected;
 
 	public function __construct(Nette\Database\Table\Selection $selected)
@@ -130,7 +130,7 @@ V šabloně `Task/default.latte` nyní místo tabulky stačí použít makro `{c
 A to je vše. Nyní podobou úpravu provedeme v `HomepagePresenter`u:
 
 /--php
-public function createComponentIncompleteTasks()
+protected function createComponentIncompleteTasks()
 {
 	return new Todo\TaskListControl($this->taskRepository->findIncomplete());
 }
@@ -161,7 +161,7 @@ Před tím, než začneme signál psát, musíme naší komponentě navíc před
 /--php
 class TaskListControl extends Nette\Application\UI\Control
 {
-	/** @var \Nette\Database\Table\Selection */
+	/** @var Nette\Database\Table\Selection */
 	private $selected;
 
 	/** @var TaskRepository */
@@ -187,7 +187,7 @@ protected function createComponentTaskList()
 V `HomepagePresenter`:
 
 /--php
-public function createComponentIncompleteTasks()
+protected function createComponentIncompleteTasks()
 {
 	return new Todo\TaskListControl($this->taskRepository->findIncomplete(), $this->taskRepository);
 }

--- a/wip/book/cs/book/database.texy
+++ b/wip/book/cs/book/database.texy
@@ -66,7 +66,6 @@ Napišme si repozitáře `UserRepository`, `TaskRepository` a `ListRepository` v
 Vytvoříme soubor `app/model/Repository.php`:
 
 /--php
-<?php
 namespace Todo;
 use Nette;
 
@@ -121,7 +120,6 @@ Doporučujeme neuvádět koncovou značku PHP `?>`, jazyk ji nevyžaduje a nemů
 A následují soubory `app/model/UserRepository.php`:
 
 /--php
-<?php
 namespace Todo;
 use Nette;
 
@@ -136,7 +134,6 @@ class UserRepository extends Repository
 `app/model/ListRepository.php`:
 
 /--php
-<?php
 namespace Todo;
 use Nette;
 
@@ -151,8 +148,6 @@ class ListRepository extends Repository
 a `app/model/TaskRepository.php`:
 
 /--php
-<?php
-
 namespace Todo;
 use Nette;
 

--- a/wip/book/cs/book/forms.texy
+++ b/wip/book/cs/book/forms.texy
@@ -135,7 +135,7 @@ Zkusíme si cvičně přidat úkol. Vyplníme text úkolu, vybereme komu má bý
 Ten nastavuje formuláři, že po jeho úspěšném odeslání se má vykonat metoda `taskFormSubmitted` z objektu `$this`, tedy z aktuálního presenteru. To ovšem znamená, že jí musíme vytvořit.
 
 /--php
-public function taskFormSubmitted(Form $form)
+public function taskFormSubmitted(Nette\Application\UI\Form $form, Nette\Utils\ArrayHash $values)
 {
 	$this->taskRepository->createTask($this->list->id, $form->values->text, $form->values->userId);
 	$this->flashMessage('Úkol přidán.', 'success');
@@ -234,7 +234,7 @@ protected function createComponentNewListForm()
 	return $form;
 }
 
-public function newListFormSubmitted(Form $form)
+public function newListFormSubmitted(Nette\Application\UI\Form $form, Nette\Utils\ArrayHash $values)
 {
 	$list = $this->listRepository->createList($form->values->title);
 	$this->flashMessage('Seznam úkolů založen.', 'success');

--- a/wip/book/cs/book/forms.texy
+++ b/wip/book/cs/book/forms.texy
@@ -135,7 +135,7 @@ Zkusíme si cvičně přidat úkol. Vyplníme text úkolu, vybereme komu má bý
 Ten nastavuje formuláři, že po jeho úspěšném odeslání se má vykonat metoda `taskFormSubmitted` z objektu `$this`, tedy z aktuálního presenteru. To ovšem znamená, že jí musíme vytvořit.
 
 /--php
-public function taskFormSubmitted(Nette\Application\UI\Form $form, Nette\Utils\ArrayHash $values)
+public function taskFormSubmitted(Nette\Application\UI\Form $form, stdClass $values)
 {
 	$this->taskRepository->createTask($this->list->id, $form->values->text, $form->values->userId);
 	$this->flashMessage('Úkol přidán.', 'success');
@@ -234,7 +234,7 @@ protected function createComponentNewListForm()
 	return $form;
 }
 
-public function newListFormSubmitted(Nette\Application\UI\Form $form, Nette\Utils\ArrayHash $values)
+public function newListFormSubmitted(Nette\Application\UI\Form $form, stdClass $values)
 {
 	$list = $this->listRepository->createList($form->values->title);
 	$this->flashMessage('Seznam úkolů založen.', 'success');

--- a/wip/book/cs/book/presenter.texy
+++ b/wip/book/cs/book/presenter.texy
@@ -201,7 +201,7 @@ V `TaskPresenter`u budeme chtít zobrazit jeden konkrétní seznam úkolů. Sezn
 /--php
 // class TaskPresenter
 
-/** @var \Nette\Database\Table\ActiveRow */
+/** @var Nette\Database\Table\ActiveRow */
 private $list;
 
 public function actionDefault($id)
@@ -291,7 +291,7 @@ protected function startup()
 	$this->listRepository = $this->context->listRepository;
 }
 
-public function beforeRender()
+protected function beforeRender()
 {
 	$this->template->lists = $this->listRepository->findAll()->order('title ASC');
 }

--- a/wip/book/en/book/database.texy
+++ b/wip/book/en/book/database.texy
@@ -76,7 +76,6 @@ In our case, we will simplify this pattern by using Nette Database, a clever too
 We will create an abstract repository `Repository` and 3 additional repositories `UserRepository`, `TaskRepository`, and `ListRepository` inherited from it. All repositories will be placed in namespace `Todo`.
 
 /--php
-<?php
 namespace Todo;
 use Nette;
 
@@ -131,7 +130,6 @@ We recommend not to use PHP closing tag `?>`. It is not required and not using i
 And the following files `app/model/UserRepository.php`:
 
 /--php
-<?php
 namespace Todo;
 use Nette;
 
@@ -146,7 +144,6 @@ class UserRepository extends Repository
 `app/model/ListRepository.php`:
 
 /--php
-<?php
 namespace Todo;
 use Nette;
 
@@ -161,8 +158,6 @@ class ListRepository extends Repository
 and `app/model/TaskRepository.php`:
 
 /--php
-<?php
-
 namespace Todo;
 use Nette;
 


### PR DESCRIPTION
- pridava public/protected/private do metod
- sjednocuje namespace (nekde zacinal s /, nekde ne)
- `createComponent`, `startup`, `beforeRender` jsou vzdy protected
- doplneny typy do parametru a return typy
- odstraneno `<?php` ze zahlavi - nekde bylo, nekde ne
- sjednocuje predavani zavislosti do presenteru, vsude jsou tedka injecty (krome ukazek na ruzne 
predavani)
- sjednocuje dedeni od presenteru
  - nekde jenom `Presenter`, nekde `\Nette\App`, nekde `Nette\App...`
- promenne `model` jsem se snazil nahradit necim jinym


-----

Zatim to jeste neni cele, tech metod je tam hodne. Spis me zajima, jestli je to podle tebe takto v poradku. @dg

Pripadne @JanTvrdik @matej21 @chemix  