### PR TITLE
bump required php version to 7.1.0

### DIFF
--- a/tester/en/homepage.texy
+++ b/tester/en/homepage.texy
@@ -25,7 +25,7 @@ And Nette Tester helps exactly with that.
 
 Installation and requirements
 =============================
-Minimal required PHP version by Tester is 7.1.0.
+Minimal required PHP version by Tester is 5.6.0 (stable version, see in [Releases |https://github.com/nette/tester/releases]).
 
 Preferred way of installation is by [Composer |https://getcomposer.org] and every following example assumes that. But the Tester can be used without it. It will be also shown below.
 

--- a/tester/en/homepage.texy
+++ b/tester/en/homepage.texy
@@ -25,7 +25,7 @@ And Nette Tester helps exactly with that.
 
 Installation and requirements
 =============================
-Minimal required PHP version by Tester is 5.6.0.
+Minimal required PHP version by Tester is 7.1.0.
 
 Preferred way of installation is by [Composer |https://getcomposer.org] and every following example assumes that. But the Tester can be used without it. It will be also shown below.
 


### PR DESCRIPTION
In the docs it's still 5.6.0, and getting this error on 7.0 for protected const:

`syntax error, unexpected 'const' (T_CONST)...`