### PR TITLE
Přidání filtru do šablony.

### DIFF
--- a/cs/quickstart/home-page.texy
+++ b/cs/quickstart/home-page.texy
@@ -164,7 +164,7 @@ Pojďme zobrazit příspěvky z blogu - šablonu upravíme následovně:
 
 		<h2>{$post->title}</h2>
 
-		<div>{$post->content}</div>
+		<div>{$post->content|truncate:256}</div>
 	</div>
 	{/foreach}
 {/block}
@@ -180,7 +180,7 @@ Pokud obnovíme prohlížeč, uvidíme výpis všech příspěvků. Výpis zatí
 
 Makro `{foreach}` iteruje přes všechny příspěvky, které jsme předali šabloně v proměnné `$posts`, a pro každý vykreslí daný kus HTML. Chová se přesně jako PHP kód.
 
-Zápisu `|date:` říkáme filtr. Filtry jsou určeny k formátování výstupu. Tento konkrétní filtr převádí datum (např. `2013-04-12`) na jeho čitelnější podobu (`April 12, 2013`). Další výchozí filtry [najdeme v dokumentaci |latte:filters] a nebo si můžeme vytvořit vlastní, když je to potřeba.
+Zápisu `|date:` říkáme filtr. Filtry jsou určeny k formátování výstupu. Tento konkrétní filtr převádí datum (např. `2013-04-12`) na jeho čitelnější podobu (`April 12, 2013`). Filtr `|truncate:` ořízne řetězec na uvedenou maximální délku a v případě že řetězec zkrátí přidá na konec trojtečku. Jelikož se jedná o náhled, nemá smysl zobrazovat celý obsah článku. Další výchozí filtry [najdeme v dokumentaci |latte:filters] a nebo si můžeme vytvořit vlastní, když je to potřeba.
 
 Ještě jedna věc. Předchozí kód můžeme zkrátit a zjednodušit. Toho docílíme záměnou *Latte maker* za *n:makra*:
 
@@ -190,7 +190,7 @@ Ještě jedna věc. Předchozí kód můžeme zkrátit a zjednodušit. Toho doc�
 
 	<h2>{$post->title}</h2>
 
-	<div>{$post->content}</div>
+	<div>{$post->content|truncate:256}</div>
 </div>
 \--
 


### PR DESCRIPTION
Myslím, že v náhledu nemá smysl zobrazovat celý obsah článku. Přidal jsem filtr `|truncate` do obou zdrojových kódů a přidal krátký popis.