### PR TITLE
Example method beforeCompile(), fix syntax error.

### DIFF
--- a/cs/di-extensions.texy
+++ b/cs/di-extensions.texy
@@ -158,7 +158,7 @@ class BlogExtension extends Nette\DI\CompilerExtension
 	{
 		$builder = $this->getContainerBuilder();
 
-		foreach ($builder->findByTag('logaware')) as $name) {
+		foreach ($builder->findByTag('logaware') as $name) {
 			$builder->getDefinition($name)->addSetup('setLogger');
 		}
 	}


### PR DESCRIPTION
beforeCompile(), fix syntax error in example.