### PR TITLE
Forms: add notes about Form::PATTERN_ICASE

### DIFF
--- a/cs/form-fields.texy
+++ b/cs/form-fields.texy
@@ -15,6 +15,7 @@ Přidá jednořádkové textové políčko (třída [TextInput |api:Nette\Forms\
 | `Form::EMAIL` | je hodnota platná e-mailová adresa?
 | `Form::URL` | je hodnota absolutní URL?
 | `Form::PATTERN` | testuje oproti regulárnímu výrazu celou hodnotu, tj. jako by byl obalen znaky ^ a $ | `string $pattern`
+| `Form::PATTERN_ICASE` | jako `Form::PATTERN`, ale case-insensitive (nezávislé na velikosti písmen); podporováno od nette/forms v2.4.9 | `string $pattern`
 | `Form::INTEGER` | je hodnota celočíselná?
 | `Form::NUMERIC` | alias pro `Form::INTEGER`
 | `Form::FLOAT` | je hodnota číslo?
@@ -86,6 +87,8 @@ Přidá políčko pro upload souboru (třída [UploadControl |api:Nette\Forms\Co
 | `Form::MAX_FILE_SIZE` | ověřuje maximální velikost souboru | `int $bytes`
 | `Form::MIME_TYPE` | ověření MIME type | `string $mimeType` nebo `$mimeTypes[]`. Může obsahovat zástupné znaky, např. `video/*`
 | `Form::IMAGE` | ověření, že jde o obrázek JPEG, PNG nebo GIF
+| `Form::PATTERN` | testuje jméno souboru oproti regulárnímu výrazu; podporováno na straně serveru od nette/forms v2.4.7, na straně klienta od nette/forms v2.4.9 | `string $pattern`
+| `Form::PATTERN_ICASE` | jako `Form::PATTERN`, ale case-insensitive (nezávislé na velikosti písmen); podporováno od nette/forms v2.4.9 | `string $pattern`
 
 /--php
 $form->addUpload('avatar', 'Avatar:')

--- a/en/form-fields.texy
+++ b/en/form-fields.texy
@@ -13,7 +13,8 @@ Adds single line text field (class [TextInput |api:Nette\Forms\Controls\TextInpu
 | `Form::LENGTH` | exact length | `[int $min, int $max]` or `int $length`
 | `Form::EMAIL` | is value a valid email address?
 | `Form::URL` | is value a valid URL?
-| `Form::PATTERN` | tests against regular expression entire value, somewhat as if it is inside ^ and a $ | `string $pattern`
+| `Form::PATTERN` | tests the entire value against a regular expression, kind of like it is inside ^ and a $ | `string $pattern`
+| `Form::PATTERN_ICASE` | like `Form::PATTERN`, but case-insensitive; since nette/forms v2.4.9 | `string $pattern`
 | `Form::INTEGER` | is value integer?
 | `Form::NUMERIC` | alias of `Form::INTEGER`
 | `Form::FLOAT` | is value a floating point number?
@@ -86,6 +87,8 @@ Adds file upload field (class [UploadControl |api:Nette\Forms\Controls\UploadCon
 | `Form::MAX_FILE_SIZE` | verifies maximal file size | `int $bytes`
 | `Form::MIME_TYPE` | checks if MIME type is valid | `string $mimeType` or `$mimeTypes[]`. Can contain wildcards, such as `video/*`.
 | `Form::IMAGE` | checks if uploaded file is JPEG, PNG or GIF
+| `Form::PATTERN` | tests the file name against a regular expression; server-side support since nette/forms v2.4.7, client-side support since nette/forms v2.4.9 | `string $pattern`
+| `Form::PATTERN_ICASE` | like `Form::PATTERN`, but case-insensitive; since nette/forms v2.4.9 | `string $pattern`
 
 /--php
 $form->addUpload('thumbnail', 'Thumbnail:')


### PR DESCRIPTION
Hey!
A little late, but still :-)

This documents nette/forms#186 and nette/forms#187.

A couple of things:
1. Should I add something like `since nette/forms > 2.4.8 or dev-master as of YYYY-MM-DD`?
2. Once we agree on this, I'll make a Czech translation.

Thanks!