### PR TITLE
Presenters: more examples of send<> methods [#670]

### DIFF
--- a/cs/presenters.texy
+++ b/cs/presenters.texy
@@ -435,6 +435,56 @@ Presenter můžeme během jeho životního cyklu kdykoliv ukončit. Obvykle tak 
 Presenter lze také ukončit přesměrováním či forwardem, viz dále.
 
 
+Odpovědi presenteru
+===================
+
+Presenter ukončí svůj běh odesláním vlastní odpovědi. Podporuje tyto odpovědi:
+
+/--php
+use Nette\Application\Responses\TextResponse;
+use Nette\Application\Responses\RedirectResponse;
+use Nette\Application\Responses\JsonResponse;
+use Nette\Application\Responses\FileResponse;
+use Nette\Application\Responses\CallbackResponse;
+use Nette\Application\Responses\ForwardResponse;
+
+public function actionFoo()
+{
+	// Prosty text
+	$this->sendResponse(new TextResponse('Hello componette!'));
+
+	// Presmeruje na jinou URL
+	$this->sendResponse(new RedirectResponse('https://componette.com', 301));
+	// Zkraceny zapis
+	$this->redirectUrl('https://compnette.com/', 301);
+
+	// JSON odpoved
+	$this->sendResponse(new JsonResponse(['hello' => 'componette']));
+	// Zkraceny zapis
+	$this->sendJson(['hello' => 'componette']);
+
+	// Odesle soubor
+	$this->sendResponse(new FileResponse(__DIR__ . '/invoice.pdf', 'Invoice 12345'));
+
+	// Custom callback
+	$this->sendResponse(new CallbackResponse(function (Http\IRequest $httpRequest, Http\IResponse $httpResponse) {
+		if (preg_match('#^text/html(?:;|$)#', $httpResponse->getHeader('Content-Type'))) {
+			require __DIR__ . '/templates/Error/500.phtml';
+		}
+	});
+
+	// Forwardovani (interni request)
+	$this->createRequest($this, 'Homepage:default', [], 'forward');
+	$this->sendResponse(new Responses\ForwardResponse($this->lastCreatedRequest));
+	// Zkraceny zapis
+	$this->forward('Homepage:default');
+}
+\--
+
+.[tip]
+Repozitář hotových vlastních odpovědí najdete na "Componette":https://componette.com/search/response.
+
+
 Přesměrování
 ============
 

--- a/en/presenters.texy
+++ b/en/presenters.texy
@@ -435,6 +435,56 @@ We can terminate a presenter anytime during its life cycle. We usually do this t
 A presenter can be terminated also by redirecting or forwarding, see below.
 
 
+Presenter Responses
+===================
+
+The Presenter finishes running by sending a custom answer. Supports these answers:
+
+/--php
+use Nette\Application\Responses\TextResponse;
+use Nette\Application\Responses\RedirectResponse;
+use Nette\Application\Responses\JsonResponse;
+use Nette\Application\Responses\FileResponse;
+use Nette\Application\Responses\CallbackResponse;
+use Nette\Application\Responses\ForwardResponse;
+
+public function actionFoo()
+{
+	// Plain text
+	$this->sendResponse(new TextResponse('Hello componette!'));
+
+	// Redirects to different URL
+	$this->sendResponse(new RedirectResponse('https://componette.com', 301));
+	// Shortcut
+	$this->redirectUrl('https://compnette.com/', 301);
+
+	// JSON response
+	$this->sendResponse(new JsonResponse(['hello' => 'componette']));
+	// Shortcut
+	$this->sendJson(['hello' => 'componette']);
+
+	// Send file
+	$this->sendResponse(new FileResponse(__DIR__ . '/invoice.pdf', 'Invoice 12345'));
+
+	// Custom callback
+	$this->sendResponse(new CallbackResponse(function (Http\IRequest $httpRequest, Http\IResponse $httpResponse) {
+		if (preg_match('#^text/html(?:;|$)#', $httpResponse->getHeader('Content-Type'))) {
+			require __DIR__ . '/templates/Error/500.phtml';
+		}
+	});
+
+	// Forwarding (internal request)
+	$this->createRequest($this, 'Homepage:default', [], 'forward');
+	$this->sendResponse(new Responses\ForwardResponse($this->lastCreatedRequest));
+	// Shortcut
+	$this->forward('Homepage:default');
+}
+\--
+
+.[tip]
+You can find a repository of completed custom responses on "Componette":https://componette.com/search/response.
+
+
 Redirection
 ===========
 


### PR DESCRIPTION
Ukazky pro:
 
- use Nette\Application\Responses\TextResponse;
- use Nette\Application\Responses\RedirectResponse;
- use Nette\Application\Responses\JsonResponse;
- use Nette\Application\Responses\FileResponse;
- use Nette\Application\Responses\CallbackResponse;
- use Nette\Application\Responses\ForwardResponse;