### PR TITLE
Configuring: Fix link to the "Invalid links" section

### DIFF
--- a/cs/configuring.texy
+++ b/cs/configuring.texy
@@ -47,7 +47,7 @@ Parametr `catchExceptions` ovlivňuje, zda dojde k zavolání error presenteru. 
 		silentLinks: ...      # default: false
 \--
 
-Volba `silentLinks` určuje, jak se Nette zachová v debug módu při tom, když se nepodaří vygenerovat odkaz. Defautlní hodnota `false` znamená, že Nette vyhodí `E_USER_WARNING` chybu. Nastavením na `true` dojde k potlačení této chybové hlášky. V produkčním prostředí se `E_USER_WARNING` vyvolá vždy. Toto chování můžeme také ovlivnit nastavením třídní proměnné [Presenteru::$invalidLinkMode"|#Neplatné odkazy].
+Volba `silentLinks` určuje, jak se Nette zachová v debug módu při tom, když se nepodaří vygenerovat odkaz. Defautlní hodnota `false` znamená, že Nette vyhodí `E_USER_WARNING` chybu. Nastavením na `true` dojde k potlačení této chybové hlášky. V produkčním prostředí se `E_USER_WARNING` vyvolá vždy. Toto chování můžeme také ovlivnit nastavením třídní proměnné [Presenteru::$invalidLinkMode|presenters#Neplatné odkazy].
 
 
 Mapování

--- a/en/configuring.texy
+++ b/en/configuring.texy
@@ -47,7 +47,7 @@ Parameter `catchExceptions` decides if the error presenter will be invoked. By c
 		silentLinks: ...      # default: false
 \--
 
-Option `silentLinks` specifies Nette behaviour in the debug mode when a link generation fails. With `false` value Nette will trigger `E_USER_WARNING`. Changing this configuration option to `true` will suppress this error. In production environment, E_USER_WARNING will be always triggered. We can also adjust this behaviour using class property [Presenter::$invalidLinkMode|#Invalid links].
+Option `silentLinks` specifies Nette behaviour in the debug mode when a link generation fails. With `false` value Nette will trigger `E_USER_WARNING`. Changing this configuration option to `true` will suppress this error. In production environment, E_USER_WARNING will be always triggered. We can also adjust this behaviour using class property [Presenter::$invalidLinkMode|presenters#Invalid links].
 
 Mapping
 -------


### PR DESCRIPTION
There is a broken link to "Invalid links" section.

The same is in the documentation for the version 3.0, but I don't know what is the best way to fix it there too. Open another pull request?