### PR TITLE
Fixed a documentation error regarding Multiple insert

### DIFF
--- a/en/database-core.texy
+++ b/en/database-core.texy
@@ -125,11 +125,13 @@ Multiple insert:
 
 /--php
 $database->query('INSERT INTO users', [
-	'name' => 'Jim',
-	'year' => 1978,
-], [
-	'name' => 'Jack',
-	'year' => 1987,
+        [
+	        'name' => 'Jim',
+	        'year' => 1978,
+        ], [
+	        'name' => 'Jack',
+	        'year' => 1987,
+        ]
 ]);
 // INSERT INTO users (`name`, `year`) VALUES ('Jim', 1978), ('Jack', 1987)
 \--


### PR DESCRIPTION
the current docs show that you can pass each row to be inserted as additional params to the query method, however when you try to do that it errors.  In looking up this error here: https://forum.nette.org/en/21412-nette-database-insert-multiple-rows-in-one-query I realized that the multiple rows need to be passed as an array in the second argument which solved the problem.