### PR TITLE
Update security-warning.texy

### DIFF
--- a/www/cs/security-warning.texy
+++ b/www/cs/security-warning.texy
@@ -5,7 +5,7 @@ Bezpečnostní varování
 **Je NESMÍRNĚ důležité,** aby soubor `config.neon` a vůbec celý adresář `app`, `log` apod. NEBYL dostupný z webového prohlížeče. Pokud neochráníte tyto adresáře před přímým přístupem z internetu, kdokoliv bude moci vidět vaše hesla a další citlivé informace.
 
 
-Jak zjistíte, že je soubor ochráněn? Jednoduše se jej pokuste otevřít v prohlížeči. Pokud váš web sídlí na adrese `http://example.com/` a zde máte umístěn adresář `app` se souborem `config.neon`, pokuste se otevřít URL `http://example.com/app/config.neon`. Prohlížeč by měl oznámit, že přístup je zakázán. Jestliže místo toho obsah konfiguračního souboru zobrazí, máte na webu vážnou bezpečností díru a musíte ji zacelit.
+Jak zjistíte, že je soubor ochráněn? Jednoduše se jej pokuste otevřít v prohlížeči. Pokud váš web sídlí na adrese `http://example.com/` a zde máte umístěn adresář `app/config` se souborem `config.neon`, pokuste se otevřít URL `http://example.com/app/config/config.neon`. Prohlížeč by měl oznámit, že přístup je zakázán. Jestliže místo toho obsah konfiguračního souboru zobrazí, máte na webu vážnou bezpečností díru a musíte ji zacelit.
 
 
 Ochránit kritické soubory před přístupem z webu je vaše zodpovědnost. Jak na to?


### PR DESCRIPTION
V bežnej adresárovej štruktúre nette je cesta ku configu app/config/config.neon a príde mi, ze v ukážke by mala byt pouzitá práve celá táto cesta. Hlavne, ak si bude bezpečnosť testovať zaciatočník, tak nebude meniť adresárovú štruktúru nette.