### PR TITLE
Configuration: removed typo.

### DIFF
--- a/en/configuring.texy
+++ b/en/configuring.texy
@@ -117,7 +117,7 @@ Other settings are as follows:
 			PDO::MYSQL_ATTR_COMPRESS: true
 			lazy: true  # establish a connection when it is needed for the first time
 			driverClass:  .... # class database driver
-		debugger: true         # show panel in Tracy baru
+		debugger: true         # show panel in Tracy bar
 		explain:  true         # show query explains in Tracy bar
 		autowired: true # enabled for first defined connection
 		conventions: discovered # or 'static' or class name, the default is 'discovered'


### PR DESCRIPTION
Removed typo. I think it's the skipped translation from Czech to English.