### PR TITLE
Form Fields: removed unnecessary constructor

### DIFF
--- a/en/form-fields.texy
+++ b/en/form-fields.texy
@@ -157,7 +157,6 @@ addCheckboxList(string|int $name, $label=null, array $items=null): static .[meth
 Adds list of checkboxes for selecting multiple elements. Array of values is passed as the third argument. The component checks if the submitted values are from the given range.
 
 /--php
-$form = new Form;
 $form->addCheckboxList('colors', 'Colors:', [
 	'r' => 'red',
 	'g' => 'green',


### PR DESCRIPTION
I think this constructor isn't needed. In all other code examples there is no constructor, so I don't see reason for having constructor here.