### PR TITLE
Tester: fixed exception method description

### DIFF
--- a/tester/en/writing-tests.texy
+++ b/tester/en/writing-tests.texy
@@ -91,7 +91,7 @@ Assert::type($type, $value) .[method]
 - class name or object directly then must pass `$value instanceof $type`
 
 
-Assert::exception($callable, $class, $message = null) .[method]
+Assert::exception($callable, $class, $message = null, $code = null) .[method]
 ---------------------------------------------------------------
 On `$callable` invocation an exception of `$class` instance must be thrown. If we pass `$message`, message of the exception must match (see [Assert::match() |#assert-match]). And if we pass `$code`, code of the exception must be the same. For example, this test fails because message of the exception does not match:
 


### PR DESCRIPTION
Checkout code of Nette Tester: https://github.com/nette/tester/blob/master/src/Framework/Assert.php.

Method header is:
`public static function exception(callable $function, string $class, string $message = null, $code = null): ?\Throwable`.

In description of method features there is `$code` parameter mentioned but it is missing in the documentation method header.