### PR TITLE
Database: removed Czech word from English text

### DIFF
--- a/en/database-core.texy
+++ b/en/database-core.texy
@@ -2,7 +2,7 @@ Database Core
 *************
 
 .[perex]
-Nette Database Core je is database abstraction layer and provides core functionality.
+Nette Database Core is database abstraction layer and provides core functionality.
 
 
 Connection and Configuration


### PR DESCRIPTION
I think it's misstake from copying Czech text and translating it into English.