### PR TITLE
Strings: removed Czech word from English documentation

### DIFF
--- a/en/strings.texy
+++ b/en/strings.texy
@@ -195,7 +195,7 @@ Returns a length of a UTF-8 string.
 
 /--php
 echo Strings::length('Nette'); // '5'
-echo Strings::length('červená'); // '7'
+echo Strings::length('red'); // '3'
 \--
 
 


### PR DESCRIPTION
I think it is better to keep English documentation in English even in this code example.