### PR TITLE
Wording & grammar fixes, part 1

### DIFF
--- a/en/database-explorer.texy
+++ b/en/database-explorer.texy
@@ -5,17 +5,17 @@ Database Explorer
 Nette Database Explorer significantly simplifies retrieving data from the database without writing SQL queries.
 
 - uses efficient queries
-- does not transmit unnecessary data
-- has elegant syntax
+- no data is transmitted unnecessarily
+- features elegant syntax
 \--
 
-Using of Database Explorer starts with the table, just call `table()` on the [Nette\Database\Context|api:] object. The easiest way to get it is [described here |database core#Connection and Configuration], but if we use Nette Database Explorer alone, it can be [manually created |#Manual creating Context].
+To use Database Explorer, start with a table - call `table()` on a [Nette\Database\Context|api:] object. The easiest way to get a context object instance is [described here |database core#Connection and Configuration], or, for case when Nette Database Explorer is used as a standalone tool, it can be [created manually|#Creating Context Manually].
 
 /--php
 $books = $context->table('book'); // db table name is 'book'
 \--
 
-It returns object [Selection |api:Nette\Database\Table\Selection], we can iterate over it and pass through all the books. The rows are [ActiveRow |api:Nette\Database\Table\ActiveRow] instances; you can read row data from their properties.
+The call returns an instance of [Selection |api:Nette\Database\Table\Selection] object, that can be iterated over to retrieve all the books. Each item (a row) is represented by an instance of [ActiveRow |api:Nette\Database\Table\ActiveRow] with data mapped to its properties:
 
 /--php
 foreach ($books as $book) {
@@ -32,15 +32,15 @@ echo $book->title;
 echo $book->author_id;
 \--
 
-Let's take a look at common use-case. You need to fetch books and their authors. It is common 1:N relationship. The often used solution is to fetch data by one SQL query with table joins. The second possibility is to fetch data separately, run one query for getting books and then get an author for each book by another query (e.g. in your foreach cycle). This could be easily optimized to run only two queries, one for books, and another for the needed authors - and this is just the way how Nette Database Explorer does it.
+Let's take a look at common use-case. You need to fetch books and their authors. It is a common 1:N relationship. The often used solution is to fetch data using one SQL query with table joins. The second possibility is to fetch data separately, run one query for getting books and then get an author for each book by another query (e.g. in your foreach cycle). This could be easily optimized to run only two queries, one for the books, and another for the needed authors - and that is exactly the way how Nette Database Explorer does it.
 
 In the examples below, we will work with the database schema in the figure. There are OneHasMany (1:N) links (author of book `author_id` and possible translator `translator_id`, which may be `null`) and ManyHasMany (M:N) link between book and its tags.
 
 [An example, including a schema, is found on GitHub |https://github.com/nette/examples/tree/master/Books].
 
-[* db-schema-1-.png *] *** Database structure for examples .<>
+[* db-schema-1-.png *] *** Database structure used in the examples .<>
 
-The following code lists the author's name for each book and all its tags. How exactly this works we will [discuss in a moment |#Working with relationships].
+The following code lists the author's name for each book and all its tags. We will [discuss in a moment |#Working with relationships] how this works internally.
 
 /--php
 $books = $context->table('book');
@@ -89,7 +89,7 @@ See possibilities how to filter and restrict rows [api:Nette\Database\Table\Sele
 | `$table->group($columns)` | Set GROUP BY
 | `$table->having($having)` | Set HAVING
 
-You can use fluent interface, for example `$table->where(...)->order(...)->limit(...)`. Multiple `where` or `whereOr` conditions are connected with the `AND` operator.
+Fluent interface can be used, for example `$table->where(...)->order(...)->limit(...)`. Multiple `where` or `whereOr` conditions are connected with the `AND` operator.
 
 Possible `where()` usage. Nette Database Explorer can automatically add needed operators for passed values:
 
@@ -131,9 +131,9 @@ $table->where('NOT id ?', $ids);
 Filtering by Another Table Value .[#joining-key]
 ------------------------------------------------
 
-Quite often you need filter results by some condition which involves another database table. These types of condition require table join. However, you don't need write them anymore.
+Quite often you need filter results by some condition which involves another database table. These types of condition require table join. However, you don't need to write them anymore.
 
-Let's say, you need to get all book which has author whose name is 'Jon'. All you need to write is just the joining key of the relation and column name in the joined table. Joining key is derived from the column which refers to table you want to join. Our example (see db schema) has column `author_id`, so we can use just part of it - `author`. `name` is column in `author` table. You can also create condition for book translator (which is connected by `translator_id` column).
+Let's say you need to get all books whose author's name is 'Jon'. All you need to write is the joining key of the relation and the column name in the joined table. The joining key is derived from the column which refers to the table you want to join. In our example (see the db schema) it is the column `author_id`, and it is sufficient to use just the first part of it - `author` (the `_id` suffix can be omitted). `name` is a column in the `author` table we would like to use. A condition for book translator (which is connected by `translator_id` column) can be created just as easily.
 
 /--php
 $books = $context->table('book');
@@ -141,9 +141,9 @@ $books->where('author.name LIKE ?', '%Jon%');
 $books->where('translator.name', 'David Grudl');
 \--
 
-The joining key logic is driven by implementation of [IConventions |api:Nette\Database\IConventions]. We encourage to use [DiscoveredConventions |api:Nette\Database\Conventions\DiscoveredConventions], which analyze your foreign keys and allows you easily work with these relationships.
+The joining key logic is driven by implementation of [IConventions |api:Nette\Database\IConventions]. We encourage to use [DiscoveredConventions |api:Nette\Database\Conventions\DiscoveredConventions], which analyzes your foreign keys and allows you to easily work with these relationships.
 
-The relationship between book and its author is 1:N. The reverse relationships is also possible. We call it **backjoin**. Take a look on another example. We would like to fetch all authors, who has written more than 3 books. To make the join reverse we use `:` (colon). Colon means that the joined relationship means hasMany (and it's quite logic, two dots is more than one). Unfortunately, Selection isn't smart enough, so we must help with the aggregation and provide some `GROUP BY` statement, also the condition must be written as the `HAVING` statement.
+The relationship between book and its author is 1:N. The reverse relationship is also possible. We call it **backjoin**. Take a look at another example. We would like to fetch all authors, who have written more than 3 books. To make the join reverse we use `:` (colon). Colon means that the joined relationship means hasMany (and it's quite logical too, as two dots are more than one dot). Unfortunately, the Selection class isn't smart enough, so we have to help with the aggregation and provide a `GROUP BY` statement, also the condition has to be written in form of `HAVING` statement.
 
 /--php
 $authors = $context->table('author');
@@ -151,9 +151,9 @@ $authors->group('author.id')
 	->having('COUNT(:book.id) > 3');
 \--
 
-Maybe you have noticed that the joining expression refers to the book, but it's not clear, if we are joining over `author_id` or `translator_id`. In the example above Selection joins over the `author_id` column, because Selection have found match with the source table - table `author`. If there wouldn't be a match and would there be more possibilities, Nette would throw [AmbiguousReferenceKeyException |api:Nette\Database\Conventions\AmbiguousReferenceKeyException].
+You may have noticed that the joining expression refers to the book, but it's not clear, whether we are joining through `author_id` or `translator_id`. In the example above, Selection joins through the `author_id` column, because a match with the source table has been found - the `author` table. If there was no such a match and there would be more possibilities, Nette would throw [AmbiguousReferenceKeyException |api:Nette\Database\Conventions\AmbiguousReferenceKeyException].
 
-To make join over `translator_id`, just provide optional parameter into joining expression.
+To make a join through `translator_id` column, provide an optional parameter within the joining expression.
 
 /--php
 $authors = $context->table('author');
@@ -161,7 +161,7 @@ $authors->group('author.id')
 	->having('COUNT(:book(translator).id) > 3')
 \--
 
-Let's take a look on some more difficult joining expression.
+Let's take a look at some more difficult joining expression.
 
 We would like to find all authors who have written something about PHP. All books have tags so we should select those authors who have written any book with the PHP tag.
 
@@ -184,42 +184,42 @@ Aggregate Queries
 | `$table->aggregation("GROUP_CONCAT($column)")` | Run any aggregation function
 
 .[caution]
-The `count()` method without the specified parameter selects all records and returns the array size, which is very inefficient. For example, if you need to calculate the number of rows for paging, always specify the first argument.
+The `count()` method without any specified parameters selects all records and returns the array size, which is very inefficient. For example, if you need to calculate the number of rows for paging, always specify the first argument.
 
 
 
 Escaping & Quoting
 ==================
 
-Database Explorer is smart and escape parameters and quotes identificators for you. You should just follow these basic rules:
+Database Explorer is smart and escape parameters and quotes identificators for you. These basic rules need to be followed, though:
 
-- keywords, functions, procedures uppercase
-- columns and tables lowercase
-- set values via parameters
+- keywords, functions, procedures must be uppercase
+- columns and tables must be lowercase
+- pass variables as parameters, do not concatenate
 
 /--php
 ->where('name like ?', 'John'); // WRONG! generates: `name` `like` ?
 ->where('name LIKE ?', 'John'); // CORRECT
 
-->where('KEY = ?', $value); // WRONG! KEY is keyword
+->where('KEY = ?', $value); // WRONG! KEY is a keyword
 ->where('key = ?', $value); // CORRECT. generates: `key` = ?
 
 ->where('name = ' . $name); // WRONG! sql injection!
 ->where('name = ?', $name); // CORRECT
 
-->select('DATE_FORMAT(created, "%d.%m.%Y")'); // WRONG! set values via parameters
+->select('DATE_FORMAT(created, "%d.%m.%Y")'); // WRONG! pass variables as parameters, do not concatenate
 ->select('DATE_FORMAT(created, ?)', '%d.%m.%Y'); // CORRECT
 \--
 
 .[warning]
-Wrong usage could produce security holes
+Wrong usage can produce security holes
 
 
 
 Fetching Data
 =============
 
-| `foreach ($table as $id => $row)` | Iterate all rows in result
+| `foreach ($table as $id => $row)` | Iterate over all rows in result
 | `$row = $table->get($id)` | Get single row with ID $id from table
 | `$row = $table->fetch()` | Get next row from the result
 | `$array = $table->fetchPairs($key, $value)` | Fetch all values to associative array
@@ -241,7 +241,7 @@ $row = $context->table('author')->insert([
 // INSERT INTO `author` (`name`, `born`) VALUES ('Ramsay Snow', null)
 \--
 
-If primary key is defined in table, it returns inserted row as ActiveRow object.
+If primary key is defined on the table, an ActiveRow object containing the inserted row is returned.
 
 Multiple insert:
 
@@ -258,7 +258,7 @@ $context->table('author')->insert([
 // INSERT INTO `author` (`name`, `born`) VALUES ('Sansa Stark', null), ('Arya Stark', null)
 \--
 
-Updating (returns count of affected rows):
+Updating (returns the count of affected rows):
 
 /--php
 $count = $context->table('author')
@@ -269,7 +269,7 @@ $count = $context->table('author')
 // UPDATE `author` SET `name`='Ned Stark' WHERE (`id` = 10)
 \--
 
-Deleting (returns count of deleted rows):
+Deleting (returns the count of deleted rows):
 
 /--php
 $count = $context->table('author')
@@ -398,12 +398,12 @@ SELECT * FROM `book` WHERE (`author_id` IN (1, 2, 3)); -- ids of fetched authors
 \--
 
 
-Manual Creating Context
+Creating Context Manually
 =======================
 
-If we've created a database connection using the application configuration, we do not have to worry about it. We have created a `Nette\Database\Context` service that we can pass through the DI.
+A database connection can be created using the application configuration. In such cases a `Nette\Database\Context` service is created and can be passed as a dependency using the DI container.
 
-However, if we use Nette Database Explorer separately, we need to create the `Nette\Database\Context` instance manually.
+However, if Nette Database Explorer is used as a standalone tool, an instance of `Nette\Database\Context` object needs to be created manually.
 
 /--php
 // $storage implements Nette\Caching\IStorage:


### PR DESCRIPTION
Hello David, maintainers.

I'm not sure you welcome partial updates, but I have to say I may not have time or enthusiasm to go over the docs as a whole, so I'm providing this ... (and hopefuly more will come in the future, if you are interested)

I believe the English version of the documentation is not up to the quality of the code of the framework itself, which may degrade the framework in the eyes of foreign viewers. That is why I decided to to give a hand here. And the database explorer was the part of the docs I (literally) stumbled upon first.

---
Also, I would advise to use the passive voice when possible, as in technical English it is preferred to "we can" / "you can". I'm not sure to what extent I'm allowed to reformulate stuff.
