### PR TITLE
Cast stdClass to iterable array

### DIFF
--- a/en/quickstart/creating-posts.texy
+++ b/en/quickstart/creating-posts.texy
@@ -80,7 +80,7 @@ Continue by adding a handler method.
 /--php
 	public function postFormSucceeded(Form $form, \stdClass $values): void
 	{
-		$post = $this->database->table('posts')->insert($values);
+		$post = $this->database->table('posts')->insert((array) $values);
 
 		$this->flashMessage("Post was published", 'success');
 		$this->redirect('show', $post->id);
@@ -128,9 +128,9 @@ Let’s also extend the form handler:
 
 		if ($postId) {
 			$post = $this->database->table('posts')->get($postId);
-			$post->update($values);
+			$post->update((array) $values);
 		} else {
-			$post = $this->database->table('posts')->insert($values);
+			$post = $this->database->table('posts')->insert((array) $values);
 		}
 
 		$this->flashMessage('Post was published', 'success');


### PR DESCRIPTION
Fix error "Argument 1 passed to Nette\Database\Table\ActiveRow::update() must be iterable, object given". Or stdClass type arguments of commentFormSucceeded() and postFormSucceeded() functions could be replaced with ArrayObject types.