### PR TITLE
[Schema] min and max methods should have float parameters

### DIFF
--- a/cs/schema.texy
+++ b/cs/schema.texy
@@ -176,21 +176,21 @@ Počet prvků lze omezit pomocí `min()` a `max()`:
 
 ```php
 // pole, nejméně 10 položek, maximálně 20 položek
-$schema = Expect::array()->min(10)->max(20);
+$schema = Expect::array()->min(10.0)->max(20.0);
 ```
 
 Délka řetězce může být omezena pomocí `min()` a `max()`:
 
 ```php
 // řetězec, nejméně 10 znaků dlouhý, maximálně 20 znaků
-$schema = Expect::string()->min(10)->max(20);
+$schema = Expect::string()->min(10.0)->max(20.0);
 ```
 
 Rozsah čísel lze omezit pomocí `min()` a `max()`:
 
 ```php
 // celé číslo, mezi 10 a 20
-$schema = Expect::int()->min(10)->max(20);
+$schema = Expect::int()->min(10.0)->max(20.0);
 ```
 
 Regulární výrazy

--- a/en/schema.texy
+++ b/en/schema.texy
@@ -176,21 +176,21 @@ You can limit the number of elements or properties using the `min()` and `max()`
 
 ```php
 // array, at least 10 items, maximum 20 items
-$schema = Expect::array()->min(10)->max(20);
+$schema = Expect::array()->min(10.0)->max(20.0);
 ```
 
 The length of a string can be constrained using the `min()` and `max()`:
 
 ```php
 // string, at least 10 characters long, maximum 20 characters
-$schema = Expect::string()->min(10)->max(20);
+$schema = Expect::string()->min(10.0)->max(20.0);
 ```
 
 Ranges of numbers are specified using a combination of `min()` and `max()`:
 
 ```php
 // integer, between 10 and 20
-$schema = Expect::int()->min(10)->max(20);
+$schema = Expect::int()->min(10.0)->max(20.0);
 ```
 
 Regular expressions


### PR DESCRIPTION
With int parameters, code fails on strict types.