### PR TITLE
removed FireLogger in Firefox, plugin is not available yet

### DIFF
--- a/tracy/cs/guide.texy
+++ b/tracy/cs/guide.texy
@@ -117,7 +117,7 @@ Jak vidíte, Laděnka je poměrně výřečná, což lze ocenit ve vývojovém p
 
 [* tracy-error2.png *]:https://nette.github.io/tracy/tracy-production.html
 
-Produkční režim potlačí zobrazování všech ladících informacích, které posíláme ven pomocí [Debugger::dump() | #Dump proměnných] nebo [Debugger::fireLog() |#Firebug a FireLogger], a samozřejmě také všech chybových zpráv, které generuje PHP. Pokud jste tedy v kódu zapomněli nějaké `Debugger::dump($obj)`, nemusíte se obávat, na produkčním serveru se nic nevypíše.
+Produkční režim potlačí zobrazování všech ladících informacích, které posíláme ven pomocí [Debugger::dump() | #Dump proměnných] nebo [Debugger::fireLog() |#š a FireLogger], a samozřejmě také všech chybových zpráv, které generuje PHP. Pokud jste tedy v kódu zapomněli nějaké `Debugger::dump($obj)`, nemusíte se obávat, na produkčním serveru se nic nevypíše.
 
 K nastavování režimu se používá první parametr metody `Debugger::enable()`. Režim lze napevno nastavit konstantou `Debugger::PRODUCTION` nebo `Debugger::DEVELOPMENT`. Další možnost je, že bude vývojový režim zapnutý při přístupu z dané IP adresy s danou hodnotou `tracy-debug` cookie. Používá se syntaxe `hodnota-cookie@ip-adresa`.
 
@@ -252,10 +252,6 @@ FireLogger
 Ne vždy lze ladící informace posílat do okna prohlížeče. Týká se to AJAXových požadavků, generování XML výstupu či obrázků. V takovým případě můžeme zasílat zprávy samostatným kanálem do FireLoggeru. Chyby úrovně Notice a Warning jsou do okna FireLoggeru dokonce zasílány automaticky. Taktéž je možné logovat výjimky, které sice aplikace zachytila, ale stojí za to na ně upozornit.
 
 Jak na to?
-
-Firefox: (nefunguje ve verzi Quantum)
-- nainstalujte si rozšíření [Firebug | http://getfirebug.com/] a [FireLogger | https://addons.mozilla.org/cs/firefox/addon/firelogger/]
-- zapněte Firebug (klávesou F12), povolte panely Síť (Net) a Logger (nechte otevřený)
 
 Chrome:
 - nainstalujte si rozšíření [FireLogger for Chrome | https://chrome.google.com/webstore/detail/firelogger-for-chrome/hmagilfopmdjkeomnjpchokglfdfjfeh]

--- a/tracy/en/guide.texy
+++ b/tracy/en/guide.texy
@@ -250,10 +250,6 @@ You cannot always send debugging information to the browser window. This applies
 
 How to do it?
 
-Firefox: (does not work in Quantum)
-- install extension [Firebug | http://getfirebug.com/] and [FireLogger | https://addons.mozilla.org/cs/firefox/addon/firelogger/]
-- turn on Firebug (using F12 key), enable tabs Net and Logger (stay on Logger)
-
 Chrome:
 - install extension [FireLogger for Chrome | https://chrome.google.com/webstore/detail/firelogger-for-chrome/hmagilfopmdjkeomnjpchokglfdfjfeh]
 - turn on Chrome DevTools (using Ctrl-Shift-I key) and open Console


### PR DESCRIPTION
Firelogger již není dostupný pro Firefox