### PR TITLE
Confusing tab spaces

### DIFF
--- a/cs/configuring.texy
+++ b/cs/configuring.texy
@@ -13,19 +13,19 @@ Přístupová oprávnění
 Uvedením pole `users` vytvoříme SimpleAuthenticator, uvedením polí `roles` nebo `resources` vytvoříme autorizátor Nette\Security\Permission.
 
 ```neon
-	security:
-		debugger: true  # panel v Debugger baru
+security:
+	debugger: true  # panel v Debugger baru
 
-		users:
-			frantisek: tajneheslo
+	users:
+		frantisek: tajneheslo
 
-		roles:
-			guest:
-			member:
-			admin: [member]  # admin dědí od membera
+	roles:
+		guest:
+		member:
+		admin: [member]  # admin dědí od membera
 
-		resources:
-			file:
+	resources:
+		file:
 ```
 
 
@@ -40,11 +40,11 @@ Chyby
 Parametr `catchExceptions` ovlivňuje, zda dojde k zavolání error presenteru. Změnou hodnoty na `true` můžeme v debug módu ověřit správnou funkčnost error presenteru.
 
 ```neon
-	application:
-		debugger: true # panel do Tracy
-		errorPresenter:  ...  # default: Nette:Error
-		catchExceptions: ...  # default: zapnuto v produkčním režimu
-		silentLinks: ...      # default: false
+application:
+	debugger: true # panel do Tracy
+	errorPresenter:  ...  # default: Nette:Error
+	catchExceptions: ...  # default: zapnuto v produkčním režimu
+	silentLinks: ...      # default: false
 ```
 
 Volba `silentLinks` určuje, jak se Nette zachová v debug módu při tom, když se nepodaří vygenerovat odkaz. Defautlní hodnota `false` znamená, že Nette vyhodí `E_USER_WARNING` chybu. Nastavením na `true` dojde k potlačení této chybové hlášky. V produkčním prostředí se `E_USER_WARNING` vyvolá vždy. Toto chování můžeme také ovlivnit nastavením třídní proměnné [Presenteru::$invalidLinkMode|presenters#Neplatné odkazy].
@@ -101,8 +101,8 @@ Databáze
 Povinný prvek je pouze `dsn`:
 
 ```neon
-	database:
-			dsn: "sqlite:%appDir%/Model/demo.db"
+database:
+		dsn: "sqlite:%appDir%/Model/demo.db"
 ```
 
 Framework vytvoří nejen objekt `Nette\Database\Connection`, ale nastavují mu i pomocné objekty jako reflection & cache a ve vývojářském režimu přidá panel do Tracy baru.
@@ -110,20 +110,20 @@ Framework vytvoří nejen objekt `Nette\Database\Connection`, ale nastavují mu 
 Další nastavení jsou tyto:
 
 ```neon
-	database:
-		dsn: 'mysql:host=127.0.0.1;dbname=test'
-		user: root
-		password: password
+database:
+	dsn: 'mysql:host=127.0.0.1;dbname=test'
+	user: root
+	password: password
 
-		options:
-			PDO::MYSQL_ATTR_COMPRESS: true
-			lazy: true  # navázání připojení až když je poprvé potřeba
-			driverClass: .... # třída ovladače databáze
+	options:
+		PDO::MYSQL_ATTR_COMPRESS: true
+		lazy: true  # navázání připojení až když je poprvé potřeba
+		driverClass: .... # třída ovladače databáze
 
-		debugger: true        # zobrazí panel v Tracy baru
-		explain:  true        # explain dotazů v Tracy bar
-		autowired: true       # povoleno u prvního spojení
-		conventions:  discovered # nebo 'static' nebo jméno třídy, výchozí je 'discovered'
+	debugger: true        # zobrazí panel v Tracy baru
+	explain:  true        # explain dotazů v Tracy bar
+	autowired: true       # povoleno u prvního spojení
+	conventions:  discovered # nebo 'static' nebo jméno třídy, výchozí je 'discovered'
 ```
 
 V položce `options` můžete uvádět další hodnoty, které najdete v dokumentaci ovladačů PDO.
@@ -131,14 +131,14 @@ V položce `options` můžete uvádět další hodnoty, které najdete v dokumen
 V konfiguračním souboru můžeme definovat i více než jedno databázové spojení:
 
 ```neon
-	database:
-		main:
-			dsn: 'mysql:host=127.0.0.1;dbname=test'
-			user: root
-			password: password
+database:
+	main:
+		dsn: 'mysql:host=127.0.0.1;dbname=test'
+		user: root
+		password: password
 
-		anotherDb:
-			dsn: 'sqlite::memory:'
+	anotherDb:
+		dsn: 'sqlite::memory:'
 ```
 
 Každé takto definované spojení vytvoří dvě služby - objekt `Nette\Database\Connection` pod názvem `database.[NAME].connection` (tedy v našem případě `database.main.connection` a `database.anotherDb.connection`) a objekt `Nette\Database\Context` pod názvem `database.[NAME].context`, který se používá při práci s vrstvou [Database Explorer].
@@ -158,8 +158,8 @@ DI kontejner
 ============
 
 ```neon
-	di:
-		debugger: false  # vypne DI panel v Debugger baru
+di:
+	debugger: false  # vypne DI panel v Debugger baru
 ```
 
 
@@ -169,27 +169,27 @@ Formuláře
 V konfiguračním souboru lze změnit výchozí chybové hlášky.
 
 ```neon
-	forms:
-		messages:
-			PROTECTION: 'Your session has expired. Please return to the home page and try again.'
- 			EQUAL: 'Please enter %s.'
- 			NOT_EQUAL: 'This value should not be %s.'
- 			FILLED: 'This field is required.'
- 			BLANK: 'This field should be blank.'
- 			MIN_LENGTH: 'Please enter at least %d characters.'
- 			MAX_LENGTH: 'Please enter no more than %d characters.'
- 			LENGTH: 'Please enter a value between %d and %d characters long.'
- 			EMAIL: 'Please enter a valid email address.'
- 			URL: 'Please enter a valid URL.'
- 			INTEGER: 'Please enter a valid integer.'
- 			FLOAT: 'Please enter a valid number.'
- 			MIN: 'Please enter a value greater than or equal to %d.'
- 			MAX: 'Please enter a value less than or equal to %d.'
- 			RANGE: 'Please enter a value between %d and %d.'
- 			MAX_FILE_SIZE: 'The size of the uploaded file can be up to %d bytes.'
- 			MAX_POST_SIZE: 'The uploaded data exceeds the limit of %d bytes.'
- 			MIME_TYPE: 'The uploaded file is not in the expected format.'
- 			IMAGE: 'The uploaded file must be image in format JPEG, GIF or PNG.'
+forms:
+	messages:
+		PROTECTION: 'Your session has expired. Please return to the home page and try again.'
+		EQUAL: 'Please enter %s.'
+		NOT_EQUAL: 'This value should not be %s.'
+		FILLED: 'This field is required.'
+		BLANK: 'This field should be blank.'
+		MIN_LENGTH: 'Please enter at least %d characters.'
+		MAX_LENGTH: 'Please enter no more than %d characters.'
+		LENGTH: 'Please enter a value between %d and %d characters long.'
+		EMAIL: 'Please enter a valid email address.'
+		URL: 'Please enter a valid URL.'
+		INTEGER: 'Please enter a valid integer.'
+		FLOAT: 'Please enter a valid number.'
+		MIN: 'Please enter a value greater than or equal to %d.'
+		MAX: 'Please enter a value less than or equal to %d.'
+		RANGE: 'Please enter a value between %d and %d.'
+		MAX_FILE_SIZE: 'The size of the uploaded file can be up to %d bytes.'
+		MAX_POST_SIZE: 'The uploaded data exceeds the limit of %d bytes.'
+		MIME_TYPE: 'The uploaded file is not in the expected format.'
+		IMAGE: 'The uploaded file must be image in format JPEG, GIF or PNG.'
 ```
 
 
@@ -225,8 +225,8 @@ HTTP proxy
 Můžete zadat HTTP proxy, aby detekce IP adresy klienta fungovala správně.
 
 ```neon
-	http:
-		proxy: 127.0.0.1  # IP adresa, rozsah, název hostitele nebo pole těchto hodnot
+http:
+	proxy: 127.0.0.1  # IP adresa, rozsah, název hostitele nebo pole těchto hodnot
 ```
 
 
@@ -236,17 +236,17 @@ Můžete zadat HTTP proxy, aby detekce IP adresy klienta fungovala správně.
 Lze přepínat HTML a XHTML režim šablon a registrovat vlastní [Latte |latte:] značky. Vlastní tagy mohou být zaregistrovány buď pomocí jména třídy nebo pomocí reference na službu. Jako výchozí je zavolána metoda `install`, ale to můžete změnit tím, že přidáte dvojtečku a jméno vaší metody.
 
 ```neon
-	latte:
-		xhtml: true  # výchozí je no
-		macros:
-			- App\MyLatteMacros::register         # statická metoda, classname nebo callable
-			- @App\MyLatteMacrosFactory           # služba s metodou install
-			- @App\MyLatteMacrosFactory::register # služba s metodou register
+latte:
+	xhtml: true  # výchozí je no
+	macros:
+		- App\MyLatteMacros::register         # statická metoda, classname nebo callable
+		- @App\MyLatteMacrosFactory           # služba s metodou install
+		- @App\MyLatteMacrosFactory::register # služba s metodou register
 
-		templateClass: App\MyTemplateClass        # výchozí je Nette\Bridges\ApplicationLatte\Template
+	templateClass: App\MyTemplateClass        # výchozí je Nette\Bridges\ApplicationLatte\Template
 
-	services:
-		- App\MyLatteMacrosFactory
+services:
+	- App\MyLatteMacrosFactory
 ```
 
 
@@ -256,15 +256,15 @@ Maily
 Standardní mailer je SendmailMailer, uvedením `smtp` aktivujeme SmtpMailer.
 
 ```neon
-	mail:
-		smtp: true # zapne SmtpMailer místo SendmailMailer
-		# nepovinné nastavení
-		host: ...
-		port: ...
-		username: ...
-		password: ...
-		secure: # povolené hodnoty jsou ssl, tls nebo null
-		timeout: ...
+mail:
+	smtp: true # zapne SmtpMailer místo SendmailMailer
+	# nepovinné nastavení
+	host: ...
+	port: ...
+	username: ...
+	password: ...
+	secure: # povolené hodnoty jsou ssl, tls nebo null
+	timeout: ...
 ```
 
 
@@ -296,15 +296,15 @@ Session
 Session standardně vyexpiruje při zavření okna prohlížeče. Dobu expirace nastavíme takto:
 
 ```neon
-	session:
-		expiration: 14 days
+session:
+	expiration: 14 days
 ```
 
 Automatické startování session:
 
 ```neon
-	session:
-		autoStart: true # výchozí hodnota je 'smart'
+session:
+	autoStart: true # výchozí hodnota je 'smart'
 ```
 
 Doporučuje se ponechat `autoStart: smart`, protože pak automaticky startuje session, pouze pokud je již vytvořena.
@@ -312,8 +312,8 @@ Doporučuje se ponechat `autoStart: smart`, protože pak automaticky startuje se
 Na sdílených hostinzích je vhodné zvolit vlastní adresář, kam se mají ukládat soubory s relacemi:
 
 ```neon
-	session:
-		savePath: "%tempDir%/sessions"
+session:
+	savePath: "%tempDir%/sessions"
 ```
 
 V tomto příkladě se `%tempDir%` nahradí hodnotou, kterou jste nastavili v `$configurator->setTempDirectory()` v `Bootstrap.php`.
@@ -321,15 +321,15 @@ V tomto příkladě se `%tempDir%` nahradí hodnotou, kterou jste nastavili v `$
 Pokud chceme platnost session (nebo autentizace) rozšířit na subdomémy, nastavíme ještě parametry cookie:
 
 ```neon
-	session:
-		cookieDomain: 'example.com'
+session:
+	cookieDomain: 'example.com'
 ```
 
 Pokud chceme zobrazit obsah session v Debugger baru:
 
 ```neon
-	session:
-		debugger: true
+session:
+	debugger: true
 ```
 
 Lze nastavovat všechny PHP [direktivy |http://www.php.net/manual/en/session.configuration.php] (ve formátu camelCase) a také [readAndClose |https://www.php.net/manual/en/function.session-start.php#refsect1-function.session-start-parameters].
@@ -341,59 +341,59 @@ Tracy debugger
 Lze konfigurovat některé parametry [Tracy |tracy:] a nastavovat panely do Debugger baru.
 
 ```neon
-	tracy:
-		# email, na který se posílají notifikace, že došlo k chybě
-		email: dev@example.com
-		fromEmail: robot@example.com
+tracy:
+	# email, na který se posílají notifikace, že došlo k chybě
+	email: dev@example.com
+	fromEmail: robot@example.com
 
-		# pro odesílání emailů použije v konfiguraci definovaný mailer. Od verze Tracy 2.5.
-		netteMailer: true
+	# pro odesílání emailů použije v konfiguraci definovaný mailer. Od verze Tracy 2.5.
+	netteMailer: true
 
-		# ve vývojovém režimu zobrazí chyby typu notice nebo warning jako BlueScreen
-		strictMode: true
+	# ve vývojovém režimu zobrazí chyby typu notice nebo warning jako BlueScreen
+	strictMode: true
 
-		# zobrazí umlčené (@) chybové hlášky
-		scream: true
+	# zobrazí umlčené (@) chybové hlášky
+	scream: true
 
-		# formát odkazu pro otevření v editoru
-		editor: editor://open/?file=%file&line=%line
+	# formát odkazu pro otevření v editoru
+	editor: editor://open/?file=%file&line=%line
 
-		# cesta k prohlížeči, který bude automaticky otevírat zalogované BlueScreen v CLI režimu
-		browser: ...
+	# cesta k prohlížeči, který bude automaticky otevírat zalogované BlueScreen v CLI režimu
+	browser: ...
 
-		# pro jaké úrovně chyb (E_WARNING, E_ALL, ...) se loguje i BlueScreen
-		logSeverity:
+	# pro jaké úrovně chyb (E_WARNING, E_ALL, ...) se loguje i BlueScreen
+	logSeverity:
 
-		# cesta k šabloně s vlastní stránkou pro chybu 500
-		errorTemplate: ...
+	# cesta k šabloně s vlastní stránkou pro chybu 500
+	errorTemplate: ...
 
-		# zobrazí Debugger Bar na spodu stránky
-		showBar: true
+	# zobrazí Debugger Bar na spodu stránky
+	showBar: true
 
-		# maximální délka řetězce vypisovaná funkcí dump()
-		maxLength: 150
+	# maximální délka řetězce vypisovaná funkcí dump()
+	maxLength: 150
 
-		# do kolika úrovní zanoření má vypisovat funkce dump()
-		maxDepth: 3
+	# do kolika úrovní zanoření má vypisovat funkce dump()
+	maxDepth: 3
 
-		# zobrazí místo, kde byla volána funkce dump()
-		showLocation: false
+	# zobrazí místo, kde byla volána funkce dump()
+	showLocation: false
 
-		editorMapping:
-			# originál: nová
-			/var/www/html: /data/web
-			/home/web: /srv/html
+	editorMapping:
+		# originál: nová
+		/var/www/html: /data/web
+		/home/web: /srv/html
 
-		# přidá panely do Debugger Baru
-		bar:
-			- Nette\Bridges\DITracy\ContainerPanel
-			- IncludePanel
-			- XDebugHelper('myIdeKey')
-			- MyPanel(@MyService)
+	# přidá panely do Debugger Baru
+	bar:
+		- Nette\Bridges\DITracy\ContainerPanel
+		- IncludePanel
+		- XDebugHelper('myIdeKey')
+		- MyPanel(@MyService)
 
-		# přidá panely do BlueScreen
-		blueScreen:
-			- DoctrinePanel::renderException
+	# přidá panely do BlueScreen
+	blueScreen:
+		- DoctrinePanel::renderException
 ```
 
 


### PR DESCRIPTION
Confusing tab spaces / indentation in documentation sometimes should make you think that there is missing 'parent' node

Better to take a look at real doc. at https://doc.nette.org/cs/3.0/configuring