### PR TITLE
Create link target for Latte documentation, fix incomatibility with Latte description

### DIFF
--- a/cs/link-generation.texy
+++ b/cs/link-generation.texy
@@ -69,7 +69,9 @@ Adresa je: {link Product:show $productId}
 Využití aktuálního odkazu
 -------------------------
 
-Blok uvnitř `{ifCurrent $link}...{/ifCurrent}` se vykoná, pokud je cíl odkazu shodný s aktuální stránkou. Značku je vhodné použít například pokud chceme aktivnímu odkazu přidat CSS třídu.
+V šabloně je možné snadno zjistit, zda je cíl odkazu shodný s aktuální stránkou. Díky tomu je možné například aktivnímu odkazu přidat CSS třídu nebo skrýt část šablony.
+
+Využívá se k tomu metoda presenteru `isLinkCurrent`.
 
 ```html
 <!-- příklady použití -->
@@ -78,13 +80,13 @@ Blok uvnitř `{ifCurrent $link}...{/ifCurrent}` se vykoná, pokud je cíl odkazu
 	<li><a href="{link Default:default}">...</a></li>
 	<li><a href="{link}">...</a></li>
 	...
-	<li {ifCurrent Default:default}class="active"{/ifCurrent}><a href="{link Default:default}">...</a></li>
+	<li {if $presenter->isLinkCurrent('Default:default')}class="active"{/if}><a href="{link Default:default}">...</a></li>
 
 	<!-- rozšíření scope -->
-	<li {ifCurrent Default:*}class="active"{/ifCurrent}><a href="{link Default:default}">...</a></li>
+	<li {if $presenter->isLinkCurrent('Default:*')}class="active"{/if}><a href="{link Default:default}">...</a></li>
 </ul>
 <!-- znegování -->
-{ifCurrent Admin:login}{else}<a href="{link Admin:login}">Přihlašte se!</a>{/ifCurrent}
+{if $presenter->isLinkCurrent('Admin:login')}{else}<a href="{link Admin:login}">Přihlašte se!</a>{/if}
 ```
 
 Přečtěte si další podrobnosti o syntaxi [Latte šablon |latte:tags].

--- a/cs/link-generation.texy
+++ b/cs/link-generation.texy
@@ -66,6 +66,9 @@ Atribut `n:href` je velmi šikovný, pokud vytváříme HTML značku `<a>`. Chce
 Adresa je: {link Product:show $productId}
 ```
 
+Využití aktuálního odkazu
+-------------------------
+
 Blok uvnitř `{ifCurrent $link}...{/ifCurrent}` se vykoná, pokud je cíl odkazu shodný s aktuální stránkou. Značku je vhodné použít například pokud chceme aktivnímu odkazu přidat CSS třídu.
 
 ```html

--- a/en/link-generation.texy
+++ b/en/link-generation.texy
@@ -66,6 +66,9 @@ The attribute `n:href` is really handy if we are creating an HTML tag `<a>`. Whe
 The address is: {link Product:show $productId}
 ```
 
+Work with current link
+----------------------
+
 `{ifCurrent $link}...{/ifCurrent}` is a conditional statement. If the link is referring to the current page, the block inside the tags is executed; otherwise it is discarded. Typical use case is adding CSS classes to the active link.
 
 ```html

--- a/en/link-generation.texy
+++ b/en/link-generation.texy
@@ -69,7 +69,9 @@ The address is: {link Product:show $productId}
 Work with current link
 ----------------------
 
-`{ifCurrent $link}...{/ifCurrent}` is a conditional statement. If the link is referring to the current page, the block inside the tags is executed; otherwise it is discarded. Typical use case is adding CSS classes to the active link.
+When working with templates, you can use presenter method `isLinkCurrent` to check linking to current page.
+
+That is crucial eg. for adding CSS class to current link or hiding part of the template.
 
 ```html
 <!-- use cases -->
@@ -78,13 +80,13 @@ Work with current link
 	<li><a href="{link Default:default}">...</a></li>
 	<li><a href="{link}">...</a></li>
 	...
-	<li {ifCurrent Default:default}class="active"{/ifCurrent}><a href="{link Default:default}">...</a></li>
+	<li {if $presenter->isLinkCurrent('Default:default')}class="active"{/if}><a href="{link Default:default}">...</a></li>
 
 	<!-- scope expanding -->
-	<li {ifCurrent Default:*}class="active"{/ifCurrent}><a href="{link Default:default}">...</a></li>
+	<li {if $presenter->isLinkCurrent('Default:*')}class="active"{/if}><a href="{link Default:default}">...</a></li>
 </ul>
 <!-- negation -->
-{ifCurrent Admin:login}{else}<a href="{link Admin:login}">Sign in!</a>{/ifCurrent}
+{if $presenter->isLinkCurrent('Admin:login')}{else}<a href="{link Admin:login}">Sign in!</a>{/if}
 ```
 
 Read more details about the syntax of [Latte templates |latte:tags].


### PR DESCRIPTION
b8084e31ba39cde7f881977ee2299f662262ef47 has broken Latte doc. Link explaining ifCurrent tag in [Links](https://latte.nette.org/en/tags#toc-available-only-in-nette-framework) section does not exist. To be exact, concrete anchor does not exist.

ifCurrent tag is marked as deprecated in Latte documentation, so I've replaced it with it's $presenter->isLinkCurrent() equivalent.

The only thing that must be done is to fix link in Latte doc - I've no clue where to send PR...