### PR TITLE
mention isModuleCurrent() method

### DIFF
--- a/cs/link-generation.texy
+++ b/cs/link-generation.texy
@@ -98,6 +98,20 @@ Místo konkrétní akce je možné uvést zástupný znak `*`, který znamená j
 {/if}
 ```
 
+Zástupný znak `*` lze použít pouze místo akce, nikoliv presenteru. Pro zjištění, zda odkazujeme na aktuální modul (nebo jeho submodul), použijeme metodu `$presenter->isModuleCurrent(moduleName)`.
+
+```html
+<ul class="menu">
+	<li n:class="$presenter->isModuleCurrent('MyEshop:Users') ? active">
+		Uživatelé
+		<ul class="submenu">
+			<li><a n:href="MyEshop:Users:Search:default">Hledat</a></li>
+			<li><a n:href="MyEshop:Users:Add:default">Nový uživatel</a></li>
+		</ul>
+	</li>
+</ul>
+```
+
 
 Odkazování v presenteru
 -----------------------

--- a/en/link-generation.texy
+++ b/en/link-generation.texy
@@ -98,6 +98,20 @@ Instead of a specific action it is possible to use a wildcard character `*`, whi
 {/if}
 ```
 
+Wildcard character `*` replaces presenter's action only, not presenter itself. Link to current module (or it's submodule) can be determined by `$presenter->isModuleCurrent(moduleName)` method.
+
+```html
+<ul class="menu">
+	<li n:class="$presenter->isModuleCurrent('MyEshop:Users') ? active">
+		Users
+		<ul class="submenu">
+			<li><a n:href="MyEshop:Users:Search:default">Search users</a></li>
+			<li><a n:href="MyEshop:Users:Add:default">Add new user</a></li>
+		</ul>
+	</li>
+</ul>
+```
+
 
 Linking in Presenter
 --------------------


### PR DESCRIPTION
Adds `isModuleCurrent()` description into link generation section.

I've mentioned modular application/modules, but I haven't found any module related part in documentation. I've linked module usage example from nette/examples repository. In case I've missed description in documentation, let me know, I'm gonna fix it.

I'm not sure if there's any way how to sync this PR with nette/application release as this method is currently in master only...

