### PR TITLE
typo

### DIFF
--- a/www/en/coding-standard.texy
+++ b/www/en/coding-standard.texy
@@ -3,7 +3,7 @@ Coding Standards
 
 This document describes rules and recommendations for developing Nette. .[perex]
 
-Nette follows the recommendations defined in the [PSR-1 |http://www.php-fig.org/psr/psr-1/] and [PSR-2 |http://www.php-fig.org/psr/psr-2/] documents with [two differences |http://php7.org/guidelines/pgs-2.html]
+Nette follows the recommendations defined in the [PSR-1 |http://www.php-fig.org/psr/psr-1/] and [PSR-2 |http://www.php-fig.org/psr/psr-2/] documents with [one difference |http://php7.org/guidelines/pgs-2.html]
 - tabs are used for indenting
 
 When contributing code to Nette, you must follow its coding standards. The easiest way how to do it is to imitate the existing Nette code.

--- a/www/en/coding-standard.texy
+++ b/www/en/coding-standard.texy
@@ -3,7 +3,7 @@ Coding Standards
 
 This document describes rules and recommendations for developing Nette. .[perex]
 
-Nette follows the recommendations defined in the [PSR-1 |http://www.php-fig.org/psr/psr-1/] and [PSR-2 |http://www.php-fig.org/psr/psr-2/] documents with [one difference |http://php7.org/guidelines/pgs-2.html]
+Nette follows the recommendations defined in the [PSR-1 |http://www.php-fig.org/psr/psr-1/] and [PSR-2 |http://www.php-fig.org/psr/psr-2/] documents with [one difference |http://php7.org/guidelines/pgs-2.html]:
 - tabs are used for indenting
 
 When contributing code to Nette, you must follow its coding standards. The easiest way how to do it is to imitate the existing Nette code.


### PR DESCRIPTION
There is only one difference, or am I missing something? (There are two differences in PSG-2, but Nette uses lowercase true/false/null, the same as PSR-2, right?)