### PR TITLE
tester: removed support for HHVM

### DIFF
--- a/tester/cs/testing-with-travis.texy
+++ b/tester/cs/testing-with-travis.texy
@@ -42,7 +42,7 @@ Vytvoření .travis.yml
 Nastavení jazyka
 ----------------
 
-Nejprve je potřeba pomocí `language` Travis informovat, pro jaký jazyk má prostředí nastavit. Na dalších řádcích uvádíme, pro jaké verze PHP budeme chtít náš projekt otestovat. Neuvedení setinkového čísla znamená použití nejnovější dostupné verze. Testy pak budou spuštěny pro každou verzi zvlášť. Nette Tester podporuje i [HHVM](http://hhvm.com), můžeme ho tedy přidat také.
+Nejprve je potřeba pomocí `language` Travis informovat, pro jaký jazyk má prostředí nastavit. Na dalších řádcích uvádíme, pro jaké verze PHP budeme chtít náš projekt otestovat. Neuvedení setinkového čísla znamená použití nejnovější dostupné verze. Testy pak budou spuštěny pro každou verzi zvlášť. Nette Tester podporoval i [HHVM](http://hhvm.com), mohli jsme ho tedy přidat také.
 
 ```yaml
 language: php


### PR DESCRIPTION
Česká stránka https://tester.nette.org/cs/testing-with-travis

Informace o odstranění podpory na https://github.com/nette/tester/releases/tag/v2.0.0

Nechal jsem tam HHVM informace, protože je zde dobře a česky vysvětleno nastavení Travisu a násobení nastavení při spouštění.

