### PR TITLE
DKIM testMode

### DIFF
--- a/cs/configuring.texy
+++ b/cs/configuring.texy
@@ -513,7 +513,6 @@ mail:
 	    selector: lovenette
 	    privateKey: %appDir%/cert/dkim.priv
 	    passPhrase: ...
-	    testMode: ...
 ```
 
 

--- a/cs/mailing.texy
+++ b/cs/mailing.texy
@@ -251,7 +251,6 @@ $options = [
 	'selector' => 'dkim',
 	'privateKey' => file_get_contents('../dkim/dkim.key'),
 	'passPhrase' => '****',
-	'testMode' => true,
 ];
 
 $mailer = new Nette\Mail\SendmailMailer; // nebo SmtpMailer

--- a/en/configuring.texy
+++ b/en/configuring.texy
@@ -507,7 +507,6 @@ mail:
 	    selector: lovenette
 	    privateKey: %appDir%/cert/dkim.priv
 	    passPhrase: ...
-	    testMode: ...
 ```
 
 

--- a/en/mailing.texy
+++ b/en/mailing.texy
@@ -251,7 +251,6 @@ $options = [
 	'selector' => 'dkim',
 	'privateKey' => file_get_contents('../dkim/dkim.key'),
 	'passPhrase' => '****',
-	'testMode' => true,
 ];
 
 $mailer = new Nette\Mail\SendmailMailer; // or SmtpMailer


### PR DESCRIPTION
`testMode` proměnná je tam pouze pro automatické testy a rozhodně bych ji nedokumentoval. Pošlu pak PR pro jeho odstraní ze samotného podepisovače, protože se to dá udělat lépe.