### PR TITLE
Configuring: samesite cookies in 2.4

### DIFF
--- a/cs/configuring.texy
+++ b/cs/configuring.texy
@@ -614,7 +614,7 @@ session:
 	handler: @handlerService
 ```
 
-Nastavení `cookieSecure` se přebírá z nastavení [#HTTP cookie], můžete navíc upravit volby `cookieDomain`.
+Nastavení `cookieSecure` se přebírá z nastavení [#HTTP cookie], můžete navíc upravit volby `cookieDomain` a `cookieSamesite`.
 
 Atribut `cookieDomain` určuje, které domény mohou cookie přijímat. Není-li uveden, cookie přijímá stejná doména, jako ji nastavila, *kromě* subdomén. Pokud je `cookieDomain` zadán, jsou zahrnuty i subdomény.
 Proto je uvedení `cookieDomain` méně omezující než vynechání. Pokud je například nastaveno `cookieDomain: nette.org`, pak jsou cookies dostupné na subdoménách, jako je `doc.nette.org`. Téhož lze dosáhnout zápisem `cookieDomain: domain`.

--- a/cs/configuring.texy
+++ b/cs/configuring.texy
@@ -619,10 +619,15 @@ Nastavení `cookieSecure` se přebírá z nastavení [#HTTP cookie], můžete na
 Atribut `cookieDomain` určuje, které domény mohou cookie přijímat. Není-li uveden, cookie přijímá stejná doména, jako ji nastavila, *kromě* subdomén. Pokud je `cookieDomain` zadán, jsou zahrnuty i subdomény.
 Proto je uvedení `cookieDomain` méně omezující než vynechání. Pokud je například nastaveno `cookieDomain: nette.org`, pak jsou cookies dostupné na subdoménách, jako je `doc.nette.org`. Téhož lze dosáhnout zápisem `cookieDomain: domain`.
 
+Atribut `cookieSamesite` vyžaduje, aby soubor cookie nebyl odesílán při přístupu z jíné domény, což poskytuje určitou ochranu před útoky [Cross-Site Request Forgery |vulnerability-protection#cross-site-request-forgery-csrf] (CSRF). Možné hodnoty jsou Strict, Lax a None.
+
 ```neon
 session:
 	# domény, které přijímají cookie
 	cookieDomain: 'example.com'  # (string) výchozí je nenastaveno
+	
+	# požadavek, aby cookie nebyla zasílán při přístupu z jiné domény
+	cookieSamesite: Lax          # (Strict|Lax|None) výchozí je nenastaveno
 ```
 
 Dále lze nastavovat všechny PHP [session direktivy |https://www.php.net/manual/en/session.configuration.php] (ve formátu camelCase):

--- a/cs/configuring.texy
+++ b/cs/configuring.texy
@@ -625,7 +625,7 @@ Atribut `cookieSamesite` vyžaduje, aby soubor cookie nebyl odesílán při př�
 session:
 	# domény, které přijímají cookie
 	cookieDomain: 'example.com'  # (string) výchozí je nenastaveno
-	
+
 	# požadavek, aby cookie nebyla zasílán při přístupu z jiné domény
 	cookieSamesite: Lax          # (Strict|Lax|None) výchozí je nenastaveno
 ```

--- a/cs/configuring.texy
+++ b/cs/configuring.texy
@@ -619,6 +619,7 @@ Nastavení `cookieSecure` se přebírá z nastavení [#HTTP cookie], můžete na
 Atribut `cookieDomain` určuje, které domény mohou cookie přijímat. Není-li uveden, cookie přijímá stejná doména, jako ji nastavila, *kromě* subdomén. Pokud je `cookieDomain` zadán, jsou zahrnuty i subdomény.
 Proto je uvedení `cookieDomain` méně omezující než vynechání. Pokud je například nastaveno `cookieDomain: nette.org`, pak jsou cookies dostupné na subdoménách, jako je `doc.nette.org`. Téhož lze dosáhnout zápisem `cookieDomain: domain`.
 
+.{data-version:2.4.10}
 Atribut `cookieSamesite` vyžaduje, aby soubor cookie nebyl odesílán při přístupu z jíné domény, což poskytuje určitou ochranu před útoky [Cross-Site Request Forgery |vulnerability-protection#cross-site-request-forgery-csrf] (CSRF). Možné hodnoty jsou Strict, Lax a None.
 
 ```neon

--- a/en/configuring.texy
+++ b/en/configuring.texy
@@ -608,7 +608,7 @@ session:
 	handler: @handlerService
 ```
 
-The `cookieSecure` settings are taken from the [#HTTP cookie] settings, you can also adjust options `cookieDomain`.
+The `cookieSecure` settings are taken from the [#HTTP cookie] settings, you can also adjust options `cookieDomain` and `cookieSamesite`.
 
 The `cookieDomain` option specifies which hosts are allowed to receive the cookie. If unspecified, it defaults to the same host that set the cookie, *excluding* subdomains. If `cookieDomain` is specified, then subdomains are always included.
 Therefore, specifying `cookieDomain` is less restrictive than omitting it. For example, if `cookieDomain: nette.org` is set, then cookies are available on subdomains like `doc.nette.org`. The same thing can be achieved by `cookieDomain: domain`.

--- a/en/configuring.texy
+++ b/en/configuring.texy
@@ -613,10 +613,15 @@ The `cookieSecure` settings are taken from the [#HTTP cookie] settings, you can 
 The `cookieDomain` option specifies which hosts are allowed to receive the cookie. If unspecified, it defaults to the same host that set the cookie, *excluding* subdomains. If `cookieDomain` is specified, then subdomains are always included.
 Therefore, specifying `cookieDomain` is less restrictive than omitting it. For example, if `cookieDomain: nette.org` is set, then cookies are available on subdomains like `doc.nette.org`. The same thing can be achieved by `cookieDomain: domain`.
 
+The `cookieSamesite` option lets servers require that a cookie shouldn't be sent with cross-origin requests, which provides some protection against [Cross-Site Request Forgery |vulnerability-protection#cross-site-request-forgery-csrf] attacks (CSRF). Possible values are Strict, Lax, and None.
+
 ```neon
 session:
 	# which hosts are allowed to receive the cookie
 	cookieDomain: 'example.com'  # (string) defaults to unset
+	
+	# require that a cookie shouldn't be sent with cross-origin requests?
+	cookieSamesite: Lax          # (Strict|Lax|None) defaults to unset
 ```
 
 You can also set all PHP [session directives |https://www.php.net/manual/en/session.configuration.php] (in camelCase format):

--- a/en/configuring.texy
+++ b/en/configuring.texy
@@ -613,6 +613,7 @@ The `cookieSecure` settings are taken from the [#HTTP cookie] settings, you can 
 The `cookieDomain` option specifies which hosts are allowed to receive the cookie. If unspecified, it defaults to the same host that set the cookie, *excluding* subdomains. If `cookieDomain` is specified, then subdomains are always included.
 Therefore, specifying `cookieDomain` is less restrictive than omitting it. For example, if `cookieDomain: nette.org` is set, then cookies are available on subdomains like `doc.nette.org`. The same thing can be achieved by `cookieDomain: domain`.
 
+.{data-version:2.4.10}
 The `cookieSamesite` option lets servers require that a cookie shouldn't be sent with cross-origin requests, which provides some protection against [Cross-Site Request Forgery |vulnerability-protection#cross-site-request-forgery-csrf] attacks (CSRF). Possible values are Strict, Lax, and None.
 
 ```neon

--- a/en/configuring.texy
+++ b/en/configuring.texy
@@ -619,7 +619,7 @@ The `cookieSamesite` option lets servers require that a cookie shouldn't be sent
 session:
 	# which hosts are allowed to receive the cookie
 	cookieDomain: 'example.com'  # (string) defaults to unset
-	
+
 	# require that a cookie shouldn't be sent with cross-origin requests?
 	cookieSamesite: Lax          # (Strict|Lax|None) defaults to unset
 ```


### PR DESCRIPTION
In Nette 2.4 `cookieSamesite` configuration parameter is implemented as of <https://forum.nette.org/cs/31207-podpora-samesite-cookie-v-nette-a-csrf>. But it is missing in documentation,