### PR TITLE
fix using tranlation filter in latte

### DIFF
--- a/cs/translations.texy
+++ b/cs/translations.texy
@@ -68,7 +68,7 @@ protected function beforeRender(): void
 Poté lze překladač používat jako jiné filtry:
 
 ```html
-<a href="basket">{'Košík'|translate}</a>
+<a href="basket">{='Košík'|translate}</a>
 <span>{$item|translate}</span>
 ```
 

--- a/en/translations.texy
+++ b/en/translations.texy
@@ -68,7 +68,7 @@ protected function beforeRender(): void
 Then the translator can be used as other filters:
 
 ```html
-<a href="basket">{'Basket'|translate}</a>
+<a href="basket">{='Basket'|translate}</a>
 <span>{$item|translate}</span>
 ```
 


### PR DESCRIPTION
`translate` macro is not working for strings without `=`.