### PR TITLE
Using `getenv` instead of `$_ENV`

### DIFF
--- a/cs/bootstrap.texy
+++ b/cs/bootstrap.texy
@@ -186,7 +186,7 @@ Jednoduše tak můžeme přidat např. environmentální proměnné, na které s
 
 ```php
 $configurator->addDynamicParameters([
-	'env' => $_ENV,
+	'env' => getenv(),
 ]);
 ```
 

--- a/en/bootstrap.texy
+++ b/en/bootstrap.texy
@@ -1,6 +1,5 @@
 Bootstrap
 *********
-
 <div class=perex>
 
 Bootstrap is boot code that initializes the environment, creates a dependency injection (DI) container, and starts the application. We will discuss:
@@ -186,7 +185,7 @@ Environment variables could be easily made available using dynamic parameters. W
 
 ```php
 $configurator->addDynamicParameters([
-	'env' => $_ENV,
+	'env' => getenv(),
 ]);
 ```
 

--- a/en/bootstrap.texy
+++ b/en/bootstrap.texy
@@ -1,5 +1,6 @@
 Bootstrap
 *********
+
 <div class=perex>
 
 Bootstrap is boot code that initializes the environment, creates a dependency injection (DI) container, and starts the application. We will discuss:


### PR DESCRIPTION
Came up because of this issue: https://github.com/docker-library/php/issues/74

In the end, the "suggested" `php.ini` config is:
```ini
; Default Value: "EGPCS"
; Development Value: "GPCS"
; Production Value: "GPCS";
; http://php.net/variables-order
variables_order = "GPCS"
```
Therefore the `$_ENV` variable is not populated.