### PR TITLE
Sentence polishing

### DIFF
--- a/cs/quickstart/authentication.texy
+++ b/cs/quickstart/authentication.texy
@@ -5,7 +5,7 @@ Nette poskytuje způsob jak naprogramovat autentifikaci na našich stránkách, 
 
 Existuje mnoho možností, jak může být uživatel ověřen. Nejčastější způsob ověření je pomocí hesla (uživatel poskytne své jméno, nebo e-mail a heslo), ale jsou zde i jiné způsoby. Možná znáte tlačítka typu "Přihlásit pomocí Facebooku", nebo přihlášení pomocí Google/Twitter/GitHub na některých stránkách. S Nette můžeme mít jakoukoliv přihlašovací metodu, nebo je klidně můžeme kombinovat. Je to jen na nás.
 
-Obyčejně bychom si nejspíš napsali vlastní authenticator, ale pro tento jednoduchý malý blog použijeme `SimpleAuthenticator`, který je v Nette předpřipraven. Poskytuje přihlášení na základě hesla a uživatelského jména, které je uloženo v konfiguračním souboru. Přidáme tedy *security* sekci do souboru konfiguračního souboru (a nezapomeneme změnit heslo):
+Obyčejně bychom si nejspíš napsali vlastní authenticator, ale pro tento jednoduchý malý blog použijeme `SimpleAuthenticator`, který je v Nette předpřipraven. Poskytuje přihlášení na základě hesla a uživatelského jména, které je uloženo v konfiguračním souboru. Přidáme sem následující *security* sekci (a nezapomeneme změnit heslo):
 
 
 ```neon .{data-file:app/config/common.neon}

--- a/cs/quickstart/comments.texy
+++ b/cs/quickstart/comments.texy
@@ -137,7 +137,7 @@ public function renderShow(int $postId): void
 {
 	...
 	$this->template->post = $post;
-	$this->template->comments = $post->related('comment')->order('created_at');
+	$this->template->comments = $post->related('comments')->order('created_at');
 }
 ```
 

--- a/en/quickstart/authentication.texy
+++ b/en/quickstart/authentication.texy
@@ -5,7 +5,7 @@ Nette provides you with guidelines on how to program authentication on your page
 
 There are many ways how a user can authenticate himself. The most common way is *password-based authentication* (user provides his name or email and a password), but there are other means as well. You may be familiar with "Login with Facebook" buttons on many websites, or login via Google/Twitter/GitHub or any other site. With Nette, you can have any authentication method you want, or you can combine them. It's up to you.
 
-Normally you would write your own authenticator, but for this simple small blog, we can use the `SimpleAuthenticator` which is bundled with Nette. It provides password-based authentication and the usernames and passwords are stored in the config file. Add a *security* section to your configuration file (and don't forget to change the password):
+Normally you would write your own authenticator, but for this simple small blog, we can use the `SimpleAuthenticator` which is bundled with Nette. It provides password-based authentication and the usernames and passwords are stored in the config file. Add the *security* section below there (and don't forget to change the password):
 
 
 ```neon .{data-file:app/config/common.neon}


### PR DESCRIPTION
Initially, my ambition was to add "common.neon" reference to the sentence since it took me a while (as a newbie following this guideline) to realize where to paste the _security_ section. Just a while ago, I noticed the file reference gets displayed when hovering my mouse over the textbox. 
So my contribution reduced to "polishing" the Czech sentence only and amending the English one accordingly.
Please consider if the NEON file reference should be mentioned in the text, or it's redundant in your opinion.
I'd be happy to update it :)