### PR TITLE
Configuration: fix tracy theme key

### DIFF
--- a/cs/configuring.texy
+++ b/cs/configuring.texy
@@ -777,8 +777,8 @@ tracy:
 	# skrýt hodnoty těchto klíčů (od Tracy 2.9)
 	keysToHide: [password, pass]  # (string[]) výchozí je []
 
-	# vizuální téma (od Tracy 2.9)
-	theme: dark                # (light|dark) výchozí je 'light'
+	# vizuální téma (od Tracy 2.8)
+	dumpTheme: dark                # (light|dark) výchozí je 'light'
 
 	# zobrazit místo, kde byla volána funkce dump()?
 	showLocation: ...          # (bool) výchozí dle verze Tracy

--- a/en/configuring.texy
+++ b/en/configuring.texy
@@ -773,8 +773,8 @@ tracy:
 	# hide values of these keys (since Tracy 2.9)
 	keysToHide: [password, pass]  # (string[]) defaults to []
 
-	# visual theme (od Tracy 2.9)
-	theme: dark                # (light|dark) defaults to 'light'
+	# visual theme (since Tracy 2.8)
+	dumpTheme: dark                # (light|dark) defaults to 'light'
 
 	# displays the location where dump() was called?
 	showLocation: ...          # (bool) default according to Tracy


### PR DESCRIPTION
Hello, 

after testing tracy 2.8 RC I found that key for theme should be 'dumpTheme' instead of 'theme' (https://github.com/nette/tracy/blob/v2.8.0-RC/src/Bridges/Nette/TracyExtension.php#L49)