### PR TITLE
Unify role naming across sections

### DIFF
--- a/cs/access-control.texy
+++ b/cs/access-control.texy
@@ -260,18 +260,18 @@ Nette přichází s vestavěnou implementací autorizátoru, a to třídou [api:
 
 - `guest`: nepřihlášený návštěvník, který může číst a procházet veřejnou část webu, tzn. číst články, komentáře a volit v anketách
 - `registered`: přihlášený registrovaný uživatel, který navíc může komentovat
-- `administrator`: může spravovat články, komentáře i ankety
+- `admin`: může spravovat články, komentáře i ankety
 
 Nadefinovali jsme si tedy určité role (`guest`, `registered` a `admin`) a zmínili zdroje (`article`, `comment`, `poll`), ke kterým mohou uživatelé s nějakou rolí přistupovat nebo provádět určité operace (`view`, `vote`, `add`, `edit`).
 
-Vytvoříme instanci třídy Permission a nadefinujeme **role**. Lze přitom využít tzv. dědičnost rolí, která zajistí, že např. uživatel s rolí `administrátor` může dělat i to co obyčejný návštěvník webu (a samozřejmě i více).
+Vytvoříme instanci třídy Permission a nadefinujeme **role**. Lze přitom využít tzv. dědičnost rolí, která zajistí, že např. uživatel s rolí administrátora (`admin`) může dělat i to co obyčejný návštěvník webu (a samozřejmě i více).
 
 ```php
 $acl = new Nette\Security\Permission;
 
 $acl->addRole('guest');
-$acl->addRole('registered', 'guest'); // registered dědí od guest
-$acl->addRole('administrator', 'registered'); // a od něj dědí administrator
+$acl->addRole('registered', 'guest'); // 'registered' dědí od 'guest'
+$acl->addRole('admin', 'registered'); // a od něj dědí 'admin'
 ```
 
 Nyní nadefinujeme i seznam **zdrojů**, ke kterým mohou uživatelé přistupovat.
@@ -298,14 +298,14 @@ $acl->allow('guest', 'poll', 'vote');
 $acl->allow('registered', 'comment', 'add');
 
 // administrátor může prohlížet a editovat cokoliv
-$acl->allow('administrator', $acl::ALL, ['view', 'edit', 'add']);
+$acl->allow('admin', $acl::ALL, ['view', 'edit', 'add']);
 ```
 
 Co když chceme někomu **zamezit** k určitému zdroji přístup?
 
 ```php
 // administrátor nemůže editovat ankety, to by bylo nedemokratické
-$acl->deny('administrator', 'poll', 'edit');
+$acl->deny('admin', 'poll', 'edit');
 ```
 
 Nyní, když máme vytvořený seznam pravidel, můžeme jednoduše klást autorizační dotazy:
@@ -335,9 +335,9 @@ $acl->isAllowed('registered', 'comment', 'edit'); // false
 Administrátor může editovat vše, kromě anket:
 
 ```php
-$acl->isAllowed('administrator', 'poll', 'vote'); // true
-$acl->isAllowed('administrator', 'poll', 'edit'); // false
-$acl->isAllowed('administrator', 'comment', 'edit'); // true
+$acl->isAllowed('admin', 'poll', 'vote'); // true
+$acl->isAllowed('admin', 'poll', 'edit'); // false
+$acl->isAllowed('admin', 'comment', 'edit'); // true
 ```
 
 Oprávění mohou také být vyhodnocována dynamicky a můžeme rozhodnutí nechat na vlastním callbacku, kterému se předají všechny parametry:


### PR DESCRIPTION
- **Role** used `admin`
- **Authorizator** used `admin`
- **Permission ACL** used `administrator`