### PR TITLE
typo

### DIFF
--- a/cs/form-validation.texy
+++ b/cs/form-validation.texy
@@ -169,7 +169,7 @@ class MyValidators
 }
 
 $input->addRule(
-	'MyValidator::divisibilityValidator',
+	'MyValidators::divisibilityValidator',
 	'Hodnota musí být násobkem čísla %d',
 	8
 );

--- a/en/form-validation.texy
+++ b/en/form-validation.texy
@@ -169,7 +169,7 @@ class MyValidators
 }
 
 $input->addRule(
-	'MyValidator::divisibilityValidator',
+	'MyValidators::divisibilityValidator',
 	'Number must be multiple of %d',
 	8
 );


### PR DESCRIPTION
**CZ:** 
Změněn callback v $input->addRule() na řádku 172 z "MyValidator::divisibilityValidator" na "MyValidators::divisibilityValidator" neboť třída MyValidator neexistuje.
**EN:** 
Changed callback on line 172 in $input->addRule() from "MyValidator::divisibilityValidator" to "MyValidators::divisibilityValidator" because class MyValidator isn't exists.