### PR TITLE
typo

### DIFF
--- a/cs/sessions.texy
+++ b/cs/sessions.texy
@@ -38,7 +38,7 @@ Nette Framework problém řeší tak, že celý prostor rozděluje na sekce (obj
 Sekci získáme ze session:
 
 ```php
-$section = $session->getSession('unikatni nazev');
+$section = $session->getSection('unikatni nazev');
 ```
 
 V presenteru stačí použít `getSession()` s parametrem:

--- a/en/sessions.texy
+++ b/en/sessions.texy
@@ -38,7 +38,7 @@ Nette Framework solves the problem by dividing the entire space into sections (o
 We get the section from the session manager:
 
 ```php
-$section = $session->getSession('unique name');
+$section = $session->getSection('unique name');
 ```
 
 In the presenter it is enough to call `getSession()` with the parameter:


### PR DESCRIPTION
Na samostatné třídě Session není metoda `getSession()`, ta je jen v presenteru.