### PR TITLE
configuring: Sync intro links with heading texts

### DIFF
--- a/en/configuring.texy
+++ b/en/configuring.texy
@@ -12,20 +12,20 @@ If you use a string that starts with `@` or has `%` anywhere in it, you need to 
 "application .[prism-token prism-atrule]":[#Application]: 	"Application .[prism-token prism-comment]"<br>
 "constants .[prism-token prism-atrule]":[#Constants]: 	"Defines PHP constants .[prism-token prism-comment]"<br>
 "database .[prism-token prism-atrule]":[#Database]: 	"Database .[prism-token prism-comment]"<br>
-"decorator .[prism-token prism-atrule]":[#decorator]: 	"Decorator .[prism-token prism-comment]"<br>
-"di .[prism-token prism-atrule]":[#DI Container]: 			"DI Container .[prism-token prism-comment]"<br>
+"decorator .[prism-token prism-atrule]":[#Decorator]: 	"Decorator .[prism-token prism-comment]"<br>
+"di .[prism-token prism-atrule]":[#DI]: 			"DI Container .[prism-token prism-comment]"<br>
 "extensions .[prism-token prism-atrule]":[#Extensions]: 	"Install additional DI extensions .[prism-token prism-comment]"<br>
 "forms .[prism-token prism-atrule]":[#Forms]: 		"Forms .[prism-token prism-comment]"<br>
 "http .[prism-token prism-atrule]":[#HTTP Headers]: 		"HTTP Headers .[prism-token prism-comment]"<br>
 "includes .[prism-token prism-atrule]":[#Including files]: 	"Including files .[prism-token prism-comment]"<br>
 "latte .[prism-token prism-atrule]":[#Latte]: 		"Latte .[prism-token prism-comment]"<br>
-"mail .[prism-token prism-atrule]":[#Mailing]: 		"Mailing .[prism-token prism-comment]"<br>
-"parameters .[prism-token prism-atrule]":[#parameters]: 	"Parameters .[prism-token prism-comment]"<br>
-"php .[prism-token prism-atrule]":[#Php]: 			"PHP configuration options .[prism-token prism-comment]"<br>
+"mail .[prism-token prism-atrule]":[#Mail]: 		"Mailing .[prism-token prism-comment]"<br>
+"parameters .[prism-token prism-atrule]":[#Parameters]: 	"Parameters .[prism-token prism-comment]"<br>
+"php .[prism-token prism-atrule]":[#PHP]: 			"PHP configuration options .[prism-token prism-comment]"<br>
 "routing .[prism-token prism-atrule]":[#Routing]: 		"Routing .[prism-token prism-comment]"<br>
 "search .[prism-token prism-atrule]":[#Search]: 		"Automatic service registration .[prism-token prism-comment]"<br>
 "security .[prism-token prism-atrule]":[#Access Control]: 	"Access Control .[prism-token prism-comment]"<br>
-"services .[prism-token prism-atrule]":[#services]: 	"Services .[prism-token prism-comment]"<br>
+"services .[prism-token prism-atrule]":[#Services and Modifications]: 	"Services .[prism-token prism-comment]"<br>
 "session .[prism-token prism-atrule]":[#Session]: 		"Session .[prism-token prism-comment]"<br>
 "tracy .[prism-token prism-atrule]":[#Tracy Debugger]: 		"Tracy Debugger .[prism-token prism-comment]"
 </pre>
@@ -351,7 +351,7 @@ forms:
 ```
 
 
-HTTP headers
+HTTP Headers
 ============
 
 ```neon
@@ -794,7 +794,7 @@ session:
 The `cookieSamesite` option affects whether the cookie is sent with [cross-origin requests |vulnerability-protection#SameSite cookie], which provides some protection against [Cross-Site Request Forgery|vulnerability-protection#cross-site-request-forgery-csrf] attecks.
 
 
-Tracy debugger
+Tracy Debugger
 ==============
 
 You can set the [Tracy |tracy:] parameters in the configuration and also add new panels to the Tracy Bar. These settings are applied only after the DI container has been created, so errors that occurred earlier cannot reflect them.


### PR DESCRIPTION
This fixes a few broken links.

I wonder if we should not have some broken link checker running in CI.
