### PR TITLE
Fix typo in sandbox docs

### DIFF
--- a/latte/en/sandbox.texy
+++ b/latte/en/sandbox.texy
@@ -33,7 +33,7 @@ Creating policies from scratch, when everything is forbidden, may not be conveni
 $policy = Latte\Sandbox\SecurityPolicy::createSafePolicy();
 ```
 
-This means that all standard macros are allowed except for `contentType`, `debugbreak`, `dump`, `extends`, `import`, `include`, `includeblock`, `layout`, `php`, `sandbox` are allowed , `snippet`, `snippetArea`, `templatePrint`, `varPrint`, `widget`.
+This means that all standard macros are allowed except for `contentType`, `debugbreak`, `dump`, `extends`, `import`, `include`, `includeblock`, `layout`, `php`, `sandbox`, `snippet`, `snippetArea`, `templatePrint`, `varPrint`, `widget`.
 All standard filters are allowed as well except for `datastream`, `noescape` and `nocheck`. Finally, access to the methods and properties of object `$iterator` is allowed too.
 
 The rules apply to the template that we insert with the new [`{sandbox}` |tags#Including Templates] tag. Which is a something like `{include}`, but it turns on sandbox mode and also doesn't pass any external variables:


### PR DESCRIPTION
there were some words left from previous version or something