### PR TITLE
fix: incorrect package in passwords

### DIFF
--- a/en/passwords.texy
+++ b/en/passwords.texy
@@ -7,7 +7,7 @@ To manage the security of our users, we never store their passwords in plaintext
 Installation:
 
 ```shell
-composer require nette/utils
+composer require nette/security
 ```
 
 The framework automatically adds a `Nette\Security\Passwords` service to the DI container under the name `security.passwords`, which you get by passing it using [dependency injection |di-passing-dependencies]:


### PR DESCRIPTION
The Passwords class is part of nette/security, not nette/utils