### PR TITLE
Fix findByTag foreach

### DIFF
--- a/doc/cs/dependency-injection/extensions.texy
+++ b/doc/cs/dependency-injection/extensions.texy
@@ -133,8 +133,7 @@ class BlogExtension extends Nette\DI\CompilerExtension
 beforeCompile() .[method]
 =========================
 
-Metoda se volá ve chvíli, kdy kontejner obsahuje všechny služby přidané jednotlivými rozšířeními v metodách `loadConfiguration` a taktéž uživatelskými konfiguračními soubory. V této fázi sestavování tedy můžeme definice služeb upravovat nebo doplnit vazby mezi nimi. Pro vyhledávání služeb v kontejneru podle tagů lze využít metodu `
-()`, podle třídy či rozhraní zase metodu `findByType()`.
+Metoda se volá ve chvíli, kdy kontejner obsahuje všechny služby přidané jednotlivými rozšířeními v metodách `loadConfiguration` a taktéž uživatelskými konfiguračními soubory. V této fázi sestavování tedy můžeme definice služeb upravovat nebo doplnit vazby mezi nimi. Pro vyhledávání služeb v kontejneru podle tagů lze využít metodu `()`, podle třídy či rozhraní zase metodu `findByType()`.
 
 ```php
 class BlogExtension extends Nette\DI\CompilerExtension

--- a/doc/cs/dependency-injection/extensions.texy
+++ b/doc/cs/dependency-injection/extensions.texy
@@ -133,7 +133,7 @@ class BlogExtension extends Nette\DI\CompilerExtension
 beforeCompile() .[method]
 =========================
 
-Metoda se volá ve chvíli, kdy kontejner obsahuje všechny služby přidané jednotlivými rozšířeními v metodách `loadConfiguration` a taktéž uživatelskými konfiguračními soubory. V této fázi sestavování tedy můžeme definice služeb upravovat nebo doplnit vazby mezi nimi. Pro vyhledávání služeb v kontejneru podle tagů lze využít metodu `()`, podle třídy či rozhraní zase metodu `findByType()`.
+Metoda se volá ve chvíli, kdy kontejner obsahuje všechny služby přidané jednotlivými rozšířeními v metodách `loadConfiguration` a taktéž uživatelskými konfiguračními soubory. V této fázi sestavování tedy můžeme definice služeb upravovat nebo doplnit vazby mezi nimi. Pro vyhledávání služeb v kontejneru podle tagů lze využít metodu `findByTag()`, podle třídy či rozhraní zase metodu `findByType()`.
 
 ```php
 class BlogExtension extends Nette\DI\CompilerExtension

--- a/doc/cs/dependency-injection/extensions.texy
+++ b/doc/cs/dependency-injection/extensions.texy
@@ -133,7 +133,8 @@ class BlogExtension extends Nette\DI\CompilerExtension
 beforeCompile() .[method]
 =========================
 
-Metoda se volá ve chvíli, kdy kontejner obsahuje všechny služby přidané jednotlivými rozšířeními v metodách `loadConfiguration` a taktéž uživatelskými konfiguračními soubory. V této fázi sestavování tedy můžeme definice služeb upravovat nebo doplnit vazby mezi nimi. Pro vyhledávání služeb v kontejneru podle tagů lze využít metodu `findByTag()`, podle třídy či rozhraní zase metodu `findByType()`.
+Metoda se volá ve chvíli, kdy kontejner obsahuje všechny služby přidané jednotlivými rozšířeními v metodách `loadConfiguration` a taktéž uživatelskými konfiguračními soubory. V této fázi sestavování tedy můžeme definice služeb upravovat nebo doplnit vazby mezi nimi. Pro vyhledávání služeb v kontejneru podle tagů lze využít metodu `
+()`, podle třídy či rozhraní zase metodu `findByType()`.
 
 ```php
 class BlogExtension extends Nette\DI\CompilerExtension
@@ -142,7 +143,7 @@ class BlogExtension extends Nette\DI\CompilerExtension
 	{
 		$builder = $this->getContainerBuilder();
 
-		foreach ($builder->findByTag('logaware') as $name) {
+		foreach ($builder->findByTag('logaware') as $name => $value) {
 			$builder->getDefinition($name)->addSetup('setLogger');
 		}
 	}

--- a/doc/en/dependency-injection/extensions.texy
+++ b/doc/en/dependency-injection/extensions.texy
@@ -142,7 +142,7 @@ class BlogExtension extends Nette\DI\CompilerExtension
 	{
 		$builder = $this->getContainerBuilder();
 
-		foreach ($builder->findByTag('logaware') as $name) {
+		foreach ($builder->findByTag('logaware') as $name => $value) {
 			$builder->getDefinition($name)->addSetup('setLogger');
 		}
 	}


### PR DESCRIPTION
Fix for extensions.texy - the foreach was missing the `$key` part and using the `$value` as such.