### PR TITLE
missing delimiters

### DIFF
--- a/latte/en/filters.texy
+++ b/latte/en/filters.texy
@@ -546,7 +546,7 @@ replaceRE(string pattern, string replace = '') .[filter]
 Replaces all occurrences according to regular expression.
 
 ```latte
-{='hello world'|replaceRE: 'l.*', 'l'}  {* outputs 'hel' *}
+{='hello world'|replaceRE: '/l.*/', 'l'}  {* outputs 'hel' *}
 ```
 
 


### PR DESCRIPTION
preg_replace(): Delimiter must not be alphanumeric or backslash

