### PR TITLE
Addition of cookie name nette-debug for version with Nette

### DIFF
--- a/tracy/tr/guide.texy
+++ b/tracy/tr/guide.texy
@@ -122,7 +122,7 @@ Gördüğünüz gibi, Tracy oldukça güzel konuşuyor. Bir geliştirme ortamın
 
 Üretim çıktı kipi, [dump() |dumper] aracılığıyla gönderilen tüm hata ayıklama bilgilerini ve elbette PHP tarafından üretilen tüm hata iletilerini bastırır. Dolayısıyla, kaynak kodda `dump($obj)` adresini unutsanız bile, üretim sunucunuzda bu konuda endişelenmenize gerek yoktur. Hiçbir şey görülmeyecektir.
 
-Çıktı modu `Debugger::enable()`'un ilk parametresi tarafından ayarlanır. `Debugger::Production` veya `Debugger::Development` sabitini belirtebilirsiniz. Diğer bir seçenek ise, uygulamaya `tracy-debug` çerezinin tanımlanmış bir değeri ile tanımlanmış bir IP adresinden erişildiğinde geliştirme modunun açık olacağı şekilde ayarlamaktır. Bunu başarmak için kullanılan sözdizimi `cookie-value@ip-address` şeklindedir.
+Çıktı modu `Debugger::enable()`'un ilk parametresi tarafından ayarlanır. `Debugger::Production` veya `Debugger::Development` sabitini belirtebilirsiniz. Diğer bir seçenek ise, uygulamaya `tracy-debug` (Nette içinde Tracy için "nette-debug") çerezinin tanımlanmış bir değeri ile tanımlanmış bir IP adresinden erişildiğinde geliştirme modunun açık olacağı şekilde ayarlamaktır. Bunu başarmak için kullanılan sözdizimi `cookie-value@ip-address` şeklindedir.
 
 Belirtilmezse, varsayılan değer olan `Debugger::Detect` kullanılır. Bu durumda, sistem bir sunucuyu IP adresine göre algılar. Bir uygulamaya genel bir IP adresi üzerinden erişiliyorsa üretim modu seçilir. Yerel bir IP adresi geliştirme moduna yol açar. Çoğu durumda modu ayarlamak gerekli değildir. Uygulamayı yerel sunucunuzda veya üretimde başlattığınızda mod doğru şekilde tanınır.
 


### PR DESCRIPTION
Hi, I propose to complete into documentation cookie name "nette-debug" for establishing secure development mode, because it is missing. In the documentation there is only mentioned "tracy-debug" for Tracy out of Nette. Iam sending alltogether 20 pullrequests for every language version one ;)