### PR TITLE
Addition of cookie name nette-debug for version with Nette

### DIFF
--- a/tracy/sl/guide.texy
+++ b/tracy/sl/guide.texy
@@ -122,7 +122,7 @@ Kot lahko vidite, je Tracy zelo zgovoren. V razvojnem okolju je to cenjeno, v pr
 
 Način produkcijskega izpisa izključuje vse informacije za odpravljanje napak, ki se pošljejo prek [funkcije dump( |dumper]), in seveda vsa sporočila o napakah, ki jih ustvari PHP. Torej, tudi če v izvorni kodi pozabite na `dump($obj)`, vam za to v produkcijskem strežniku ni treba skrbeti. Nič se ne bo videlo.
 
-Način izpisa je določen s prvim parametrom `Debugger::enable()`. Določite lahko konstanto `Debugger::Production` ali `Debugger::Development`. Druga možnost je, da ga nastavite tako, da bo razvojni način vklopljen, ko bo aplikacija dostopna z določenega naslova IP z določeno vrednostjo piškotka `tracy-debug`. Sintaksa, ki se uporablja za dosego tega, je `cookie-value@ip-address`.
+Način izpisa je določen s prvim parametrom `Debugger::enable()`. Določite lahko konstanto `Debugger::Production` ali `Debugger::Development`. Druga možnost je, da ga nastavite tako, da bo razvojni način vklopljen, ko bo aplikacija dostopna z določenega naslova IP z določeno vrednostjo piškotka `tracy-debug` za Tracy, ki se uporablja zunaj Nette, ali `nette-debug` za Tracy znotraj Nette. Sintaksa, ki se uporablja za dosego tega, je `cookie-value@ip-address`.
 
 Če ni določena, se uporabi privzeta vrednost `Debugger::Detect`. V tem primeru sistem zazna strežnik po naslovu IP. Produkcijski način se izbere, če je aplikacija dostopna prek javnega naslova IP. Lokalni naslov IP vodi v razvojni način. V večini primerov načina ni treba določiti. Način je pravilno prepoznan, ko zaženete aplikacijo v lokalnem strežniku ali v produkcijskem strežniku.
 


### PR DESCRIPTION
Hi, I propose to complete into documentation cookie name "nette-debug" for establishing secure development mode, because it is missing. In the documentation there is only mentioned "tracy-debug" for Tracy out of Nette. Iam sending alltogether 20 pullrequests for every language version one ;)