### PR TITLE
Addition of cookie name nette-debug for version with Nette

### DIFF
--- a/tracy/pt/guide.texy
+++ b/tracy/pt/guide.texy
@@ -122,7 +122,7 @@ Como você pode ver, Tracy é bastante eloquente. É apreciada em um ambiente de
 
 O modo de saída de produção suprime todas as informações de depuração que são enviadas via [dump() |dumper] e, é claro, todas as mensagens de erro geradas pelo PHP. Portanto, mesmo que você esqueça `dump($obj)` no código fonte, você não precisa se preocupar com isso em seu servidor de produção. Nada será visto.
 
-O modo de saída é definido pelo primeiro parâmetro do `Debugger::enable()`. Você pode especificar uma constante `Debugger::Production` ou `Debugger::Development`. Outra opção é configurá-la de forma que o modo de desenvolvimento esteja ativado quando a aplicação for acessada a partir de um endereço IP definido com um valor definido de `tracy-debug` cookie. A sintaxe utilizada para conseguir isto é `cookie-value@ip-address`.
+O modo de saída é definido pelo primeiro parâmetro do `Debugger::enable()`. Você pode especificar uma constante `Debugger::Production` ou `Debugger::Development`. Outra opção é configurá-la de forma que o modo de desenvolvimento esteja ativado quando a aplicação for acessada a partir de um endereço IP definido com um valor definido de `tracy-debug` cookie para Tracy usado fora do Nette, ou `nette-debug` para Tracy dentro do Nette. A sintaxe utilizada para conseguir isto é `cookie-value@ip-address`.
 
 Se não for especificado, é usado o valor padrão `Debugger::Detect`. Neste caso, o sistema detecta um servidor por endereço IP. O modo de produção é escolhido se uma aplicação for acessada através de um endereço IP público. Um endereço IP local leva ao modo de desenvolvimento. Não é necessário definir o modo na maioria dos casos. O modo é reconhecido corretamente quando você está lançando a aplicação em seu servidor local ou em produção.
 


### PR DESCRIPTION
Hi, I propose to complete into documentation cookie name "nette-debug" for establishing secure development mode, because it is missing. In the documentation there is only mentioned "tracy-debug" for Tracy out of Nette. Iam sending alltogether 20 pullrequests for every language version one ;)