### PR TITLE
Addition of cookie name nette-debug for version with Nette

### DIFF
--- a/tracy/hu/guide.texy
+++ b/tracy/hu/guide.texy
@@ -122,7 +122,7 @@ Amint láthatod, Tracy elég ékesszóló. Fejlesztői környezetben értékelhe
 
 A termelési kimeneti mód elnyom minden hibakeresési információt, amelyet a [dump() |dumper] segítségével küld ki, és természetesen a PHP által generált összes hibaüzenetet. Tehát, még ha el is felejted a `dump($obj)` címet a forráskódban, a termelő szerveren nem kell aggódnod emiatt. Semmi sem lesz látható.
 
-A kimeneti módot a `Debugger::enable()` első paramétere határozza meg. A `Debugger::Production` vagy a `Debugger::Development` konstans megadható. Másik lehetőség, hogy úgy állítsuk be, hogy a fejlesztési mód akkor legyen bekapcsolva, ha az alkalmazást egy meghatározott IP-címről érik el a `tracy-debug` cookie meghatározott értékével. Az ehhez használt szintaxis a `cookie-value@ip-address`.
+A kimeneti módot a `Debugger::enable()` első paramétere határozza meg. A `Debugger::Production` vagy a `Debugger::Development` konstans megadható. Másik lehetőség, hogy úgy állítsuk be, hogy a fejlesztési mód akkor legyen bekapcsolva, ha az alkalmazást egy meghatározott IP-címről érik el a `tracy-debug` (`nette-debug` Tracy számára a Netten belül) cookie meghatározott értékével. Az ehhez használt szintaxis a `cookie-value@ip-address`.
 
 Ha nincs megadva, akkor az alapértelmezett `Debugger::Detect` értéket használjuk. Ebben az esetben a rendszer az IP-cím alapján érzékeli a kiszolgálót. A termelési módot választja, ha egy alkalmazás nyilvános IP-címen keresztül érhető el. A helyi IP-cím a fejlesztési módhoz vezet. A legtöbb esetben nincs szükség a mód beállítására. Az üzemmód helyesen kerül felismerésre, ha az alkalmazást a helyi kiszolgálón vagy a termelésben indítja el.
 


### PR DESCRIPTION
Hi, I propose to complete into documentation cookie name "nette-debug" for establishing secure development mode, because it is missing. In the documentation there is only mentioned "tracy-debug" for Tracy out of Nette. Iam sending alltogether 20 pullrequests for every language version one ;)