### PR TITLE
Addition of cookie name nette-debug for version with Nette

### DIFF
--- a/tracy/pl/guide.texy
+++ b/tracy/pl/guide.texy
@@ -123,7 +123,7 @@ Jak widać, Laden jest dość lakoniczny, co można docenić w środowisku progr
 
 Tryb produkcyjny wyłącza wyświetlanie wszystkich informacji o debugowaniu, które wysyłamy za pomocą [dump() |dumper], oraz oczywiście wszystkich komunikatów o błędach generowanych przez PHP. Więc jeśli zapomniałeś o jakiejś `dump($obj)` w swoim kodzie, nie martw się, nic nie zostanie wydrukowane na serwerze produkcyjnym.
 
-Pierwszy parametr metody `Debugger::enable()` służy do ustawienia trybu. Tryb może być ustalony za pomocą stałej `Debugger::Production` lub `Debugger::Development`. Inną opcją jest to, że tryb deweloperski będzie włączony przy dostępie z danego adresu IP o danej wartości `tracy-debug` cookie. Stosowana składnia to `hodnota-cookie@ip-adresa`.
+Pierwszy parametr metody `Debugger::enable()` służy do ustawienia trybu. Tryb może być ustalony za pomocą stałej `Debugger::Production` lub `Debugger::Development`. Inną opcją jest to, że tryb deweloperski będzie włączony przy dostępie z danego adresu IP o danej wartości `tracy-debug` cookie dla Tracy używany poza Nette lub `nette-debug` dla Tracy w Nette. Stosowana składnia to `hodnota-cookie@ip-adresa`.
 
 Jeśli go nie określisz, domyślnie jest to `Debugger::Detect`, w takim przypadku tryb jest wykrywany przez adres IP serwera - jeśli jest on dostępny przez publiczny adres IP, działa w trybie produkcyjnym, jeśli jest na lokalnym adresie IP, działa w trybie deweloperskim. Dzięki temu w zdecydowanej większości przypadków nie ma potrzeby ustawiania trybu i będzie on prawidłowo wykrywany przez to, czy aplikacja działa na swoim lokalnym serwerze, czy w ruchu na żywo.
 


### PR DESCRIPTION
Hi, I propose to complete into documentation cookie name "nette-debug" for establishing secure development mode, because it is missing. In the documentation there is only mentioned "tracy-debug" for Tracy out of Nette. Iam sending alltogether 20 pullrequests for every language version one ;)