### PR TITLE
Doplnění názvu cookie nette-debug pro verzi s Nette

### DIFF
--- a/tracy/cs/guide.texy
+++ b/tracy/cs/guide.texy
@@ -123,7 +123,7 @@ Jak vidíte, Laděnka je poměrně výřečná, což lze ocenit ve vývojovém p
 
 Produkční režim potlačí zobrazování všech ladících informacích, které posíláme ven pomocí [dump() |dumper], a samozřejmě také všech chybových zpráv, které generuje PHP. Pokud jste tedy v kódu zapomněli nějaké `dump($obj)`, nemusíte se obávat, na produkčním serveru se nic nevypíše.
 
-K nastavování režimu se používá první parametr metody `Debugger::enable()`. Režim lze napevno nastavit konstantou `Debugger::Production` nebo `Debugger::Development`. Další možnost je, že bude vývojový režim zapnutý při přístupu z dané IP adresy s danou hodnotou `tracy-debug` cookie. Používá se syntaxe `hodnota-cookie@ip-adresa`.
+K nastavování režimu se používá první parametr metody `Debugger::enable()`. Režim lze napevno nastavit konstantou `Debugger::Production` nebo `Debugger::Development`. Další možnost je, že bude vývojový režim zapnutý při přístupu z dané IP adresy s danou hodnotou `tracy-debug` cookie pro Tracy použitou mimo Nette, nebo `nette-debug` pro Tracy v rámci Nette. Používá se syntaxe `hodnota-cookie@ip-adresa`.
 
 Pokud jej neuvedeme, má výchozí hodnotu `Debugger::Detect` a v takovém případě se detekuje režim podle IP adresy serveru - je-li dostupný přes veřejnou IP adresu, běží v produkčním režimu, je-li na lokální, tak ve vývojářském. V drtivé většině případů tak není potřeba režim nastavovat a správně se rozezná podle toho, jestli aplikaci spouštíme na svém lokálním serveru nebo v ostrém provozu.
 


### PR DESCRIPTION
Hi, I propose to complete into documentation cookie name "nette-debug" for establishing secure development mode, because it is missing. In the documentation there is only mentioned "tracy-debug" for Tracy out of Nette. Iam sending alltogether 20 pullrequests for every language version one ;)