### PR TITLE
Adding a line to the Tracy activation code sample

### DIFF
--- a/tracy/cs/guide.texy
+++ b/tracy/cs/guide.texy
@@ -34,9 +34,11 @@ Můžete si také stáhnout celý balíček jako soubor [tracy.phar |https://git
 Použití
 =======
 
-*Laděnku* aktivujeme snadno. Stačí přidat do kódu, nejlépe hned za načtení knihovny (např. `require 'vendor/autoload.php'`) a dříve než se odešle jakýkoliv výstup, následující:
+*Laděnku* aktivujeme snadno. Stačí přidat do kódu, nejlépe hned za načtení knihovny a dříve než se odešle jakýkoliv výstup, následující řádky:
 
 ```php
+require 'vendor/autoload.php;
+
 use Tracy\Debugger;
 
 Debugger::enable();


### PR DESCRIPTION
A complete Tracy novice will easily miss the mention of the require 'vendor/autoload.php' line, which is hidden in a block of text in the current version of the documentation, while it is a mandatory line for proper activation of Tracy.
