### PR TITLE
Default static parameters - addition 2

### DIFF
--- a/dependency-injection/cs/configuration.texy
+++ b/dependency-injection/cs/configuration.texy
@@ -52,6 +52,10 @@ Na konkrétní klíč se odkážeme jako `%mailer.user%`.
 
 Pokud potřebujete ve vašem kódu, například třídě, zjistit hodnotu jakékoliv parametru, tak jej do této třídy předejte. Například v konstruktoru. Neexistuje žádný globální objekt představující konfiguraci, kterého by se třídy dotazovaly na hodnoty parametrů. To by bylo porušením principu dependency injection.
 
+Defaultní parametry
+-------------------
+
+Do konfigurace jsou automaticky přidány parametry `appDi`r, `wwwDir`, `tempDir`, `vendorDir`, `debugMode` a `consoleMode`.
 
 Služby
 ======


### PR DESCRIPTION
Hi, information about default static parameters is important. It should be prominently listed with its own title in both the Configuration section and the Bootstrap section, as it is related to both topics. I send 2 PRs to each section separately.
