### PR TITLE
Minimal description of tag {form}{/form}

### DIFF
--- a/forms/cs/rendering.texy
+++ b/forms/cs/rendering.texy
@@ -87,6 +87,11 @@ Složitější formulářové prvky, jako je RadioList nebo CheckboxList, lze ta
 {/foreach}
 ```
 
+`{form}{/form}`
+---------------
+
+Tag `{form "formName"}...{/form}` je alternativní zápis k `<form n:name="formName">...</form>`.
+
 
 Návrh kódu `{formPrint}`
 ------------------------


### PR DESCRIPTION
Latte tag {form}{/form} is insufficiently described in the documentation. The tag is mentioned in Latte https://latte.nette.org/cs/tags, in the paragraph "Only available with Nette Forms". Here is just a link that leads to the Nette Forms documentation: https://doc.nette.org/cs/forms/rendering#toc-latte, but again we can't find any definition of this tag.

Since the tag {form "formName"}{/form} is essentially an alternative notation for <form n:name="formName" ...>, which is well described in the documentation, I suggest inserting only a small separate paragraph where it would be clearly explained .

+ change correspondingly the link from documentation Latte