### PR TITLE
Finding template file - complete description of function

### DIFF
--- a/application/cs/templates.texy
+++ b/application/cs/templates.texy
@@ -42,6 +42,11 @@ Cestu k šablonám odvodí presenter podle jednoduché logiky. Zkusí, zda exist
 - `templates/<Presenter>/<view>.latte`
 - `templates/<Presenter>.<view>.latte`
 
+Pokud šablonu nenajde, hledá v adresáři `/templates` o úroveň výše tj. na stejné úrovni jako je adresář  s třídou presenteru:
+
+- `templates/<Presenter>/<view>.latte`
+- `templates/<Presenter>.<view>.latte`
+
 Pokud šablonu nenajde, je odpovědí [chyba 404|presenters#Chyba 404 a spol.].
 
 Můžete také změnit view pomocí `$this->setView('jineView')`. Nebo místo dohledávání přímo určit jméno souboru se šablonou pomocí `$this->template->setFile('/path/to/template.latte')`.


### PR DESCRIPTION
Hi, presenter actually searches more files as templates than written in the documentation - see: https://github.com/nette/application/blob/master/src/Application/UI/Presenter.php#L514

First he searches files in /template directory insight directory with presenter class. After that he searches files in /template directory one level higher e.g. at the same level as directory with presenter class. This is very useful feature and many developers use this.

I propose to complete the description of the searching template files in the documentation.
