### PR TITLE
AVIF image Forms support and MimeType chaining

### DIFF
--- a/forms/cs/configuration.texy
+++ b/forms/cs/configuration.texy
@@ -52,7 +52,7 @@ forms:
 		MaxFileSize: 'Velikost nahraného souboru může být nejvýše %d bytů.'
 		MaxPostSize: 'Nahraná data překračují limit %d bytů.'
 		MimeType: 'Nahraný soubor není v očekávaném formátu.'
-		Image: 'Nahraný soubor musí být obraz ve formátu JPEG, GIF, PNG nebo WebP.'
+		Image: 'Nahraný soubor musí být obraz ve formátu JPEG, GIF, PNG, WebP nebo AVIF.'
 		Nette\Forms\Controls\SelectBox::Valid: 'Vyberte prosím platnou možnost.'
 		Nette\Forms\Controls\UploadControl::Valid: 'Při nahrávání souboru došlo k chybě.'
 		Nette\Forms\Controls\CsrfProtection::Protection: 'Vaše relace vypršela. Vraťte se na domovskou stránku a zkuste to znovu.'

--- a/forms/cs/controls.texy
+++ b/forms/cs/controls.texy
@@ -218,7 +218,7 @@ Přidá políčko pro upload souboru (třída [UploadControl |api:Nette\Forms\Co
 
 ```php
 $form->addUpload('avatar', 'Avatar:')
-	->addRule($form::Image, 'Avatar musí být JPEG, PNG, GIF or WebP.')
+	->addRule($form::Image, 'Avatar musí být JPEG, PNG, GIF, WebP or AVIF.')
 	->addRule($form::MaxFileSize, 'Maximální velikost je 1 MB.', 1024 * 1024);
 ```
 

--- a/forms/cs/validation.texy
+++ b/forms/cs/validation.texy
@@ -61,7 +61,7 @@ U prvků `addUpload()`, `addMultiUpload()` lze použít i následující pravidl
 
 | `MaxFileSize` | maximální velikost souboru | `int`
 | `MimeType` | MIME type, povoleny zástupné znaky (`'video/*'`) | `string\|string[]`
-| `Image` | obrázek JPEG, PNG, GIF, WebP | -
+| `Image` | obrázek JPEG, PNG, GIF, WebP, AVIF | -
 | `Pattern` | jméno souboru vyhovuje regulárnímu výrazu | `string`
 | `PatternInsensitive` | jako `Pattern`, ale nezávislé na velikosti písmen | `string`
 

--- a/forms/cs/validation.texy
+++ b/forms/cs/validation.texy
@@ -65,6 +65,8 @@ U prvků `addUpload()`, `addMultiUpload()` lze použít i následující pravidl
 | `Pattern` | jméno souboru vyhovuje regulárnímu výrazu | `string`
 | `PatternInsensitive` | jako `Pattern`, ale nezávislé na velikosti písmen | `string`
 
+`MimeType` a `Image` mohou být použity společně. Můžete řetězit více `MimeType` dohromady.
+
 `MimeType` a `Image` vyžadují PHP rozšíření `fileinfo`. Že je soubor či obrázek požadovaného typu detekují na základě jeho signatury a **neověřují integritu celého souboru.** Zda není obrázek poškozený lze zjistit například pokusem o jeho [načtení|http:request#toImage].
 
 U prvků `addMultiUpload()`, `addCheckboxList()`, `addMultiSelect()` lze použít i následující pravidla pro omezení počtu vybraných položek resp. uploadovaných souborů:

--- a/forms/en/configuration.texy
+++ b/forms/en/configuration.texy
@@ -24,7 +24,7 @@ forms:
 		MaxFileSize: 'The size of the uploaded file can be up to %d bytes.'
 		MaxPostSize: 'The uploaded data exceeds the limit of %d bytes.'
 		MimeType: 'The uploaded file is not in the expected format.'
-		Image: 'The uploaded file must be image in format JPEG, GIF, PNG or WebP.'
+		Image: 'The uploaded file must be image in format JPEG, GIF, PNG, WebP or AVIF.'
 		Nette\Forms\Controls\SelectBox::Valid: 'Please select a valid option.'
 		Nette\Forms\Controls\UploadControl::Valid: 'An error occurred during file upload.'
 		Nette\Forms\Controls\CsrfProtection::Protection: 'Your session has expired. Please return to the home page and try again.'

--- a/forms/en/controls.texy
+++ b/forms/en/controls.texy
@@ -218,7 +218,7 @@ Adds file upload field (class [UploadControl |api:Nette\Forms\Controls\UploadCon
 
 ```php
 $form->addUpload('avatar', 'Avatar:')
-	->addRule($form::Image, 'Avatar must be JPEG, PNG, GIF or WebP')
+	->addRule($form::Image, 'Avatar must be JPEG, PNG, GIF, WebP or AVIF')
 	->addRule($form::MaxFileSize, 'Maximum size is 1 MB', 1024 * 1024);
 ```
 

--- a/forms/en/validation.texy
+++ b/forms/en/validation.texy
@@ -61,7 +61,7 @@ For controls `addUpload()`, `addMultiUpload()` the following rules can also be u
 
 | `MaxFileSize` | maximal file size | `int`
 | `MimeType` | MIME type, accepts wildcards (`'video/*'`) | `string\|string[]`
-| `Image` | uploaded file is JPEG, PNG, GIF, WebP | -
+| `Image` | uploaded file is JPEG, PNG, GIF, WebP, AVIF | -
 | `Pattern` | file name matches regular expression | `string`
 | `PatternInsensitive` | like `Pattern`, but case-insensitive | `string`
 

--- a/forms/en/validation.texy
+++ b/forms/en/validation.texy
@@ -65,6 +65,8 @@ For controls `addUpload()`, `addMultiUpload()` the following rules can also be u
 | `Pattern` | file name matches regular expression | `string`
 | `PatternInsensitive` | like `Pattern`, but case-insensitive | `string`
 
+The `MimeType` and `Image` can be used in combination. You can chain multiple `MimeType`s together.
+
 The `MimeType` and `Image` require PHP extension `fileinfo`. Whether a file or image is of the required type is detected by its signature. The integrity of the entire file is not checked. You can find out if an image is not corrupted for example by trying to [load it|http:request#toImage].
 
 For controls `addMultiUpload()`, `addCheckboxList()`, `addMultiSelect()` the following rules can also be used to limit the number of selected items, respectively uploaded files:


### PR DESCRIPTION
- new feature? yes
- BC break? no

Added AVIF image support for Forms.
Added ability to chain multiple MimeType validators  together and prevent deletion of previously set rules.
