### PR TITLE
Fix typo in syntax.texy

### DIFF
--- a/latte/en/syntax.texy
+++ b/latte/en/syntax.texy
@@ -9,7 +9,7 @@ Below is a minimal template that illustrates a few basics elements: tags, n:attr
 
 ```latte
 {* this is a comment *}
-<ul n:if="$items">                {* n:if is n:atribut *}
+<ul n:if="$items">                {* n:if is n:attribute *}
 {foreach $items as $item}         {* tag representing foreach loop *}
 	<li>{$item|capitalize}</li>   {* tag that prints a variable with a filter *}
 {/foreach}                        {* end of cycle *}


### PR DESCRIPTION
Fix typo of `atribut` to `attribute`

- Typo Fix
- BC break: no
- Doc PR: nette/docs