### PR TITLE
Grammar corrected in documentation

### DIFF
--- a/latte/en/template-inheritance.texy
+++ b/latte/en/template-inheritance.texy
@@ -2,7 +2,7 @@ Template Inheritance and Reusability
 ************************************
 
 .[perex]
-Template reusability and inheritance mechanisms are here to boosts your productivity because each template contains only its unique contents and the repeated elements and structures are reused. We introduce three concepts: [#layout inheritance], [#horizontal reuse] and [#unit inheritance].
+Template reusability and inheritance mechanisms are here to boost your productivity because each template contains only its unique contents and the repeated elements and structures are reused. We introduce three concepts: [#layout inheritance], [#horizontal reuse] and [#unit inheritance].
 
 The concept of Latte template inheritance is similar to PHP class inheritance. You define a **parent template** that other **child templates** can extend from and can override parts of the parent template. It works great when elements share a common structure. Sounds complicated? Don't worry, it's not.
 
@@ -30,7 +30,7 @@ Let’s look at layout template inheritance by starting with an example. This is
 </html>
 ```
 
-The `{block}` tags defines three blocks that child templates can fill in. All the block tag does is to tell the template engine that a child template may override those portions of the template by defining their own block of the same name.
+The `{block}` tags define three blocks that child templates can fill in. All the block tag does is tell the template engine that a child template may override those portions of the template by defining their own block of the same name.
 
 A child template might look like this:
 
@@ -46,7 +46,7 @@ A child template might look like this:
 
 The `{layout}` tag is the key here. It tells the template engine that this template “extends” another template. When Latte renderes this template, first it locates the parent – in this case, `layout.latte`.
 
-At that point, the template engine will notice the three block tags in `layout.latte` and replace those blocks with the contents of the child template. Note that since the child template didn’t define the *footer* block, the contents from the parent template is used instead. Content within a `{block}` tag in a parent template is always used as a fallback.
+At that point, the template engine will notice the three block tags in `layout.latte` and replace those blocks with the contents of the child template. Note that since the child template didn’t define the *footer* block, the content from the parent template is used instead. Content within a `{block}` tag in a parent template is always used as a fallback.
 
 The output might look like:
 
@@ -76,7 +76,7 @@ In a child template, blocks can only be located either at the top level or insid
 {/block}
 ```
 
-Also a block will always be created in regardless of whether the surrounding `{if}` condition is evaluated to be true or false. Contrary to what you might think, this template does define a block.
+Also a block will always be created regardless of whether the surrounding `{if}` condition is evaluated to be true or false. Contrary to what you might think, this template does define a block.
 
 ```latte
 {if false}
@@ -96,7 +96,7 @@ If you want the output inside block to be displayed conditionally, use the follo
 {/block}
 ```
 
-Data outside of a blocks in a child template are executed before the layout template is rendered, thus you can use it to define variables like `{var $foo = bar}` and propagate data to the whole inheritance chain:
+Data outside of blocks in a child template are executed before the layout template is rendered, thus you can use it to define variables like `{var $foo = bar}` and propagate data to the whole inheritance chain:
 
 ```latte
 {layout 'layout.latte'}
@@ -213,7 +213,7 @@ The tag can also be written as [n:attribute|syntax#n:attributes]:
 Local Blocks
 ------------
 
-Every block overrides content of parent block of the same name. Except for local blocks. They are something like private methods in class. You can create a template without worrying that – due to coincidence of block names – they would be overwritten by second template.
+Every block overrides content of parent block of the same name. Except for local blocks. They are something like private methods in class. You can create a template without worrying that – due to coincidence of block names – they would be overwritten by a second template.
 
 ```latte
 {block local helper}
@@ -236,13 +236,13 @@ To print a block in a specific place, use the `{include blockname}` tag:
 <h1>{include title}</h1>
 ```
 
-You can also display block from another template:
+You can also display a block from another template:
 
 ```latte
 {include footer from 'main.latte'}
 ```
 
-Printed block have not access to the variables of the active context, except if the block is defined in the same file where it is included. However they have access to the global variables.
+Printed blocks do not have access to the variables of the active context, except if the block is defined in the same file where it is included. However they do have access to the global variables.
 
 You can pass variables to the block in the following way:
 
@@ -257,7 +257,7 @@ You can use a variable or any expression in PHP as the block name. In this case,
 {include block $name}
 ```
 
-Block can also be printed inside itself, which is useful, for example, when rendering a tree structure:
+A block can also be printed inside itself, which is useful, for example, when rendering a tree structure:
 
 ```latte
 {define menu, $items}
@@ -275,7 +275,7 @@ Block can also be printed inside itself, which is useful, for example, when rend
 {/define}
 ```
 
-Instead of `{include menu, ...}` we can also write `{include this, ...}` where `this` means current block.
+Instead of `{include menu, ...}` we can also write `{include this, ...}` where `this` means the current block.
 
 Printed content can be modified by [filters|syntax#filters]. The following example removes all HTML and title-cases it:
 
@@ -332,7 +332,7 @@ Imagine you have a helper template with a collection of definitions on how to dr
 {/define}
 ```
 
-Arguments of a definitions are always optional with default value `null`, unless default value is specified (here `'text'` is the default value for `$type`). Parameter types can also be declared: `{define input, string $name, ...}`.
+Arguments of a definition are always optional with default value `null`, unless default value is specified (here `'text'` is the default value for `$type`). Parameter types can also be declared: `{define input, string $name, ...}`.
 
 The template with the definitions is loaded using [`{import}` |#horizontal-reuse]. The definitions themselves are rendered [in the same way as the blocks |#Printing Blocks]:
 
@@ -409,7 +409,7 @@ Tips
 ----
 Here are some tips for working with blocks:
 
-- The last top-level block does not need to have closing tag (block ends with the end of the document). This simplifies the writing of child templates, which one primary block.
+- The last top-level block does not need to have closing tag (block ends with the end of the document). This simplifies the writing of child templates with one primary block.
 
 - For extra readability, you can optionally give a name to your `{/block}` tag, for example `{/block footer}`. However, the name  must match the block name. In larger templates, this technique helps you see which block tags are being closed.
 
@@ -480,7 +480,7 @@ The unit inheritance takes the idea of layout inheritance to the level of conten
 
 In unit inheritance the `{embed}` tag is the key. It combines the behavior of `{include}` and `{layout}`. It allows you to include another template’s or block's contents and optionally pass variables, just like `{include}` does. It also allows you to override any block defined inside the included template, like `{layout}` does.
 
-For example we are going to use the collapsible accordion element. Let’s take a look at the element skeleton in template `collapsible.latte`:
+For example, we are going to use the collapsible accordion element. Let’s take a look at the element skeleton in the template `collapsible.latte`:
 
 ```latte
 <section class="collapsible {$modifierClass}">
@@ -494,9 +494,9 @@ For example we are going to use the collapsible accordion element. Let’s take 
 </section>
 ```
 
-The `{block}` tags defines two blocks that child templates can fill in. Yes, like in the case of parent template in the layout inheritance template. You also see `$modifierClass` variable.
+The `{block}` tags defines two blocks that child templates can fill in. Yes, like in the case of parent template in the layout inheritance template. You also see a `$modifierClass` variable.
 
-Let's use our element in template. This is where `{embed}` comes in. It’s a super powerful piece of kit that lets us do all the things: include element's template contents, add variables to it, and add blocks with custom HTML to it:
+Let's use our element in a template. This is where `{embed}` comes in. It’s a super powerful piece of kit that lets us do all the things: include an element's template contents, add variables to it, and add blocks with custom HTML to it:
 
 ```latte
 {embed 'collapsible.latte', modifierClass: my-style}
@@ -526,7 +526,7 @@ The output might look like:
 </section>
 ```
 
-Blocks inside embed tags form a separate layer independent of other blocks. Therefore, they can have the same name as the block outside the embed and are not affected in any way. Using the tag [include|#Printing Blocks] inside `{embed}` tags you can insert blocks here created, blocks from embedded template (which *are not* [local|#Local Blocks]), and also blocks from main template which *are* local. You can also [import blocks|#Horizontal Reuse] from other files:
+Blocks inside embed tags form a separate layer independent of other blocks. Therefore, they can have the same name as the block outside the embed and are not affected in any way. Using the tag [include|#Printing Blocks] inside `{embed}` tags you can insert blocks created here, blocks from an embedded template (which *are not* [local|#Local Blocks]), and also blocks from the main template which *are* local. You can also [import blocks|#Horizontal Reuse] from other files:
 
 ```latte
 {block outer}…{/block}
@@ -547,7 +547,7 @@ Blocks inside embed tags form a separate layer independent of other blocks. Ther
 {/embed}
 ```
 
-Embeded templates have not access to the variables of the active context, but they have access to the global variables.
+Embedded templates do not have access to the variables of the active context, but they do have access to the global variables.
 
 With `{embed}` you can insert not only templates but also other blocks, so the previous example could be written like this:
 
@@ -580,7 +580,7 @@ If we pass an expression to `{embed}` and it is not clear whether it is a block 
 Use Cases
 =========
 
-There are various types of inheritance and code reuse in Latte. Let's summarize the main concepts for more clearance:
+There are various types of inheritance and code reuse in Latte. Let's summarize the main concepts for more clarity:
 
 
 `{include template}`


### PR DESCRIPTION
Some English grammar corrections that make the documentation a little easier to understand and sound more professional.

Just trying to help make things better as I'm reading!

- bug fix / new feature?   no
- BC break? no
- doc PR: nette/docs#???  yes, just English corrections

<!--
Please use the latest released version (ie. last tagged commit) as a base for PR.

Describe your changes here to communicate to the maintainers why we should accept this pull request.

Please add new tests to show the fix or feature works. And take a moment to read the contributing guide https://nette.org/en/contributing

Thanks for contributing to Nette!
-->
