### PR TITLE
fix german di container translation

### DIFF
--- a/dependency-injection/de/container.texy
+++ b/dependency-injection/de/container.texy
@@ -44,7 +44,7 @@ Wir fragen den Container einfach nach dem Objekt und müssen nicht mehr wissen, 
 Bis jetzt hat der Container alles hart kodiert. Wir gehen also den nächsten Schritt und fügen Parameter hinzu, um den Container wirklich nützlich zu machen:
 
 ```php
-Klasse Container
+class Container
 {
 	public function __construct(
 		private array $parameters,
@@ -75,7 +75,7 @@ Aufmerksame Leser haben vielleicht ein Problem bemerkt. Jedes Mal, wenn ich ein 
 Also fügen wir eine Methode `getService()` hinzu, die immer wieder die gleichen Instanzen zurückgibt:
 
 ```php
-Klasse Container
+class container
 {
 	private array $services = [];
 
@@ -103,7 +103,7 @@ Beim ersten Aufruf von z.B. `$container->getService('Database')` wird `createDat
 Wir ändern auch den Rest des Containers, um `getService()` zu verwenden:
 
 ```php
-Klasse Container
+class Container
 {
 	// ...
 
@@ -134,6 +134,6 @@ $controller = $container->getService('UserController');
 $database = $container->getService('Database');
 ```
 
-Wie Sie sehen können, ist es nicht schwer, ein DIC zu schreiben. Bemerkenswert ist, dass die Objekte selbst nicht wissen, dass sie von einem Container erstellt werden. Es ist also möglich, jedes beliebige Objekt in PHP auf diese Weise zu erstellen, ohne den Quellcode zu verändern.
+Wie Sie sehen können, ist es nicht schwer, einen DIC zu schreiben. Bemerkenswert ist, dass die Objekte selbst nicht wissen, dass sie von einem Container erstellt werden. Es ist also möglich, jedes beliebige Objekt in PHP auf diese Weise zu erstellen, ohne den Quellcode zu verändern.
 
 Die manuelle Erstellung und Pflege einer Containerklasse kann schnell zu einem Alptraum werden. Deshalb werden wir im nächsten Kapitel über [Nette DI Container |nette-container] sprechen, die sich fast automatisch erzeugen und aktualisieren können.


### PR DESCRIPTION
Fixes the german translation for the dependency injection container documentation. This probably was an oversight when translating to german. 

Not a breaking change and no issue to be assigned.
