### PR TITLE
Improvement of chapter "Výrazové prostředky"

### DIFF
--- a/dependency-injection/cs/services.texy
+++ b/dependency-injection/cs/services.texy
@@ -73,7 +73,7 @@ services:
 	router: @routerFactory::create()
 ```
 
-Všimněte si, že pro jednoduchost se místo `->` používá `::`, viz [#výrazové prostředky]. Vygenerují se tyto tovární metody:
+Všimněte si, že pro jednoduchost se místo `->` používá `::`, viz [#syntaktické výrazové prostředky]. Vygenerují se tyto tovární metody:
 
 ```php
 public function createServiceDatabase(): PDO
@@ -136,7 +136,7 @@ services:
 	foo: Foo(_, %appDir%)
 ```
 
-Jako argumenty lze předávat služby, používat parametry a mnohem více, viz [#výrazové prostředky].
+Jako argumenty lze předávat služby, používat parametry a mnohem více, viz [#syntaktické výrazové prostředky].
 
 
 Setup
@@ -197,7 +197,7 @@ services:
 			- @anotherService::setFoo(@self)
 ```
 
-Všimněte si, že pro jednoduchost se místo `->` používá `::`, viz [#výrazové prostředky]. Vygeneruje se taková tovární metoda:
+Všimněte si, že pro jednoduchost se místo `->` používá `::`, viz [#syntaktické výrazové prostředky]. Vygeneruje se taková tovární metoda:
 
 ```php
 public function createServiceFoo(): Foo
@@ -210,10 +210,12 @@ public function createServiceFoo(): Foo
 ```
 
 
-Výrazové prostředky
-===================
+Syntaktické výrazové prostředky
+===============================
 
-Nette DI nám dává mimořádně bohaté výrazové prostředky, pomocí kterých můžeme zapsat téměř cokoliv. V konfiguračních souborech tak můžeme využívat [parametry|configuration#parametry]:
+Nette DI nám dává mimořádně bohaté syntaktické prvky, pomocí kterých můžeme zapsat téměř cokoliv. V konfiguračních souborech můžeme využívat:
+
+[Parametry|configuration#parametry] definované v sekci parameters:
 
 ```neon
 # parametr
@@ -226,20 +228,7 @@ Nette DI nám dává mimořádně bohaté výrazové prostředky, pomocí který
 '%wwwDir%/images'
 ```
 
-Dále vytvářet objekty, volat metody a funkce:
-
-```neon
-# vytvoření objektu
-DateTime()
-
-# volání statické metody
-Collator::create(%locale%)
-
-# volání PHP funkce
-::getenv(DB_USER)
-```
-
-Odkazovat se na služby buď jejich jménem nebo pomocí typu:
+Odkazovat se na služby buď jejich jménem nebo pomocí typu (znak @ na začátku znamená, že se jedná o službu):
 
 ```neon
 # služba dle názvu
@@ -249,6 +238,25 @@ Odkazovat se na služby buď jejich jménem nebo pomocí typu:
 @Nette\Database\Connection
 ```
 
+Vytvářet objekty (závorky jsou povinné):
+
+```neon
+# vytvoření objektu
+DateTime()
+```
+
+Volat metody a funkce:
+
+```neon
+# volání statické metody objektu
+Collator::create(%locale%)
+
+# volání nestatické metody služby
+@resolverFactory::create(%locale%)
+
+# volání globální PHP funkce
+::getenv(DB_USER)
+```
 Používat first-class callable syntax: .{data-version:3.2.0}
 
 ```neon
@@ -260,10 +268,17 @@ Používat konstanty:
 
 ```neon
 # konstanta třídy
-FilesystemIterator::SKIP_DOTS
+FilesystemIterator::SkipDots
 
 # globální konstantu získáme PHP funkcí constant()
 ::constant(PHP_VERSION)
+```
+
+Používat veřejné properties služeb
+
+```neon
+# public property služby - závorky jsou povinné
+@configProvider::$cookiePath()
 ```
 
 Volání metod lze řetězit stejně jako v PHP. Jen pro jednoduchost se místo `->` používá `::`:


### PR DESCRIPTION
The term 'výrazové prostředky' is correct, but a regular developer understands the word "syntaxe/syntaktický prostředek" better, the title could be alternatively shorter "Syntaktické prostředky".

I suggest:

- rearranging the order of items and putting service calls in second place - so that it is possible to give an example with a call to a non-static service method as a demonstration of services.

- separating the creation of objects from the use of methods and functions for clarity.

- adding these missing items:
    - calling a non-static service method
    - using a public service property
