### PR TITLE
latte/type-system: Fix typo

### DIFF
--- a/latte/bg/type-system.texy
+++ b/latte/bg/type-system.texy
@@ -21,7 +21,7 @@
 class CatalogTemplateParameters
 {
 	public function __construct(
-		public string $langs,
+		public string $lang,
 		/** @var ProductEntity[] */
 		public array $products,
 		public Address $address,
@@ -35,7 +35,7 @@ $latte->render('template.latte', new CatalogTemplateParameters(
 ));
 ```
 
-След това в началото на шаблона поставете тага `{templateType}` с пълното име на класа (включително namespace). Това дефинира, че в шаблона има променливи `$langs` и `$products`, включително съответните типове. Типовете на локалните променливи можете да посочите с помощта на таговете [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Дефиниции].
+След това в началото на шаблона поставете тага `{templateType}` с пълното име на класа (включително namespace). Това дефинира, че в шаблона има променливи `$lang` и `$products`, включително съответните типове. Типовете на локалните променливи можете да посочите с помощта на таговете [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Дефиниции].
 
 От този момент IDE може да ви подсказва правилно.
 

--- a/latte/cs/type-system.texy
+++ b/latte/cs/type-system.texy
@@ -21,7 +21,7 @@ Jak začít používat typy? Vytvořte si třídu šablony, např. `CatalogTempl
 class CatalogTemplateParameters
 {
 	public function __construct(
-		public string $langs,
+		public string $lang,
 		/** @var ProductEntity[] */
 		public array $products,
 		public Address $address,
@@ -35,7 +35,7 @@ $latte->render('template.latte', new CatalogTemplateParameters(
 ));
 ```
 
-A dále na začátek šablony vložte značku `{templateType}` s plným názvem třídy (včetně namespace). To definuje, že v šabloně jsou proměnné `$langs` a `$products` včetně příslušných typů. Typy lokálních proměnných můžete uvést pomocí značek [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Definice].
+A dále na začátek šablony vložte značku `{templateType}` s plným názvem třídy (včetně namespace). To definuje, že v šabloně jsou proměnné `$lang` a `$products` včetně příslušných typů. Typy lokálních proměnných můžete uvést pomocí značek [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Definice].
 
 Od té chvíle vám může IDE správně našeptávat.
 

--- a/latte/de/type-system.texy
+++ b/latte/de/type-system.texy
@@ -21,7 +21,7 @@ Wie beginnt man mit der Verwendung von Typen? Erstellen Sie eine Template-Klasse
 class CatalogTemplateParameters
 {
 	public function __construct(
-		public string $langs,
+		public string $lang,
 		/** @var ProductEntity[] */
 		public array $products,
 		public Address $address,
@@ -35,7 +35,7 @@ $latte->render('template.latte', new CatalogTemplateParameters(
 ));
 ```
 
-Fügen Sie dann am Anfang des Templates das Tag `{templateType}` mit dem vollständigen Klassennamen (einschließlich Namespace) ein. Dies definiert, dass im Template die Variablen `$langs` und `$products` einschließlich der entsprechenden Typen vorhanden sind. Die Typen lokaler Variablen können Sie mit den Tags [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Definition] angeben.
+Fügen Sie dann am Anfang des Templates das Tag `{templateType}` mit dem vollständigen Klassennamen (einschließlich Namespace) ein. Dies definiert, dass im Template die Variablen `$lang` und `$products` einschließlich der entsprechenden Typen vorhanden sind. Die Typen lokaler Variablen können Sie mit den Tags [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Definition] angeben.
 
 Von diesem Moment an kann Ihnen die IDE korrekt Vorschläge machen.
 

--- a/latte/el/type-system.texy
+++ b/latte/el/type-system.texy
@@ -21,7 +21,7 @@
 class CatalogTemplateParameters
 {
 	public function __construct(
-		public string $langs,
+		public string $lang,
 		/** @var ProductEntity[] */
 		public array $products,
 		public Address $address,
@@ -35,7 +35,7 @@ $latte->render('template.latte', new CatalogTemplateParameters(
 ));
 ```
 
-Και στη συνέχεια, στην αρχή του προτύπου, εισαγάγετε το tag `{templateType}` με το πλήρες όνομα της κλάσης (συμπεριλαμβανομένου του namespace). Αυτό ορίζει ότι στο πρότυπο υπάρχουν οι μεταβλητές `$langs` και `$products` συμπεριλαμβανομένων των αντίστοιχων τύπων τους. Μπορείτε να δηλώσετε τους τύπους των τοπικών μεταβλητών χρησιμοποιώντας τα tags [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Ορισμοί define].
+Και στη συνέχεια, στην αρχή του προτύπου, εισαγάγετε το tag `{templateType}` με το πλήρες όνομα της κλάσης (συμπεριλαμβανομένου του namespace). Αυτό ορίζει ότι στο πρότυπο υπάρχουν οι μεταβλητές `$lang` και `$products` συμπεριλαμβανομένων των αντίστοιχων τύπων τους. Μπορείτε να δηλώσετε τους τύπους των τοπικών μεταβλητών χρησιμοποιώντας τα tags [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Ορισμοί define].
 
 Από εκείνη τη στιγμή, το IDE σας μπορεί να παρέχει σωστή αυτόματη συμπλήρωση.
 

--- a/latte/en/type-system.texy
+++ b/latte/en/type-system.texy
@@ -21,7 +21,7 @@ How to start using types? Create a template class, e.g., `CatalogTemplateParamet
 class CatalogTemplateParameters
 {
 	public function __construct(
-		public string $langs,
+		public string $lang,
 		/** @var ProductEntity[] */
 		public array $products,
 		public Address $address,
@@ -35,7 +35,7 @@ $latte->render('template.latte', new CatalogTemplateParameters(
 ));
 ```
 
-Then insert the `{templateType}` tag with the full class name (including the namespace) at the beginning of the template. This defines that the variables `$langs` and `$products` exist in the template, including their respective types. You can also specify the types of local variables using the [`{var}` |tags#var-default], `{varType}`, and [`{define}` |template-inheritance#Definitions] tags.
+Then insert the `{templateType}` tag with the full class name (including the namespace) at the beginning of the template. This defines that the variables `$lang` and `$products` exist in the template, including their respective types. You can also specify the types of local variables using the [`{var}` |tags#var-default], `{varType}`, and [`{define}` |template-inheritance#Definitions] tags.
 
 From this point on, your IDE can correctly provide autocompletion.
 

--- a/latte/es/type-system.texy
+++ b/latte/es/type-system.texy
@@ -21,7 +21,7 @@ Los tipos declarados son informativos y Latte no los verifica en este momento.
 class CatalogTemplateParameters
 {
 	public function __construct(
-		public string $langs,
+		public string $lang,
 		/** @var ProductEntity[] */
 		public array $products,
 		public Address $address,
@@ -35,7 +35,7 @@ $latte->render('template.latte', new CatalogTemplateParameters(
 ));
 ```
 
-Y luego, al principio de la plantilla, inserte la etiqueta `{templateType}` con el nombre completo de la clase (incluido el namespace). Esto define que en la plantilla existen las variables `$langs` y `$products` con sus tipos correspondientes. Puede indicar los tipos de las variables locales usando las etiquetas [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Definiciones define].
+Y luego, al principio de la plantilla, inserte la etiqueta `{templateType}` con el nombre completo de la clase (incluido el namespace). Esto define que en la plantilla existen las variables `$lang` y `$products` con sus tipos correspondientes. Puede indicar los tipos de las variables locales usando las etiquetas [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Definiciones define].
 
 A partir de ese momento, su IDE puede sugerir correctamente.
 

--- a/latte/fr/type-system.texy
+++ b/latte/fr/type-system.texy
@@ -21,7 +21,7 @@ Comment commencer à utiliser les types ? Créez une classe de template, par exe
 class CatalogTemplateParameters
 {
 	public function __construct(
-		public string $langs,
+		public string $lang,
 		/** @var ProductEntity[] */
 		public array $products,
 		public Address $address,
@@ -35,7 +35,7 @@ $latte->render('template.latte', new CatalogTemplateParameters(
 ));
 ```
 
-Ensuite, au début du template, insérez la balise `{templateType}` avec le nom complet de la classe (y compris le namespace). Cela définit que les variables `$langs` et `$products` existent dans le template, y compris leurs types respectifs. Vous pouvez spécifier les types des variables locales à l'aide des balises [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Définitions].
+Ensuite, au début du template, insérez la balise `{templateType}` avec le nom complet de la classe (y compris le namespace). Cela définit que les variables `$lang` et `$products` existent dans le template, y compris leurs types respectifs. Vous pouvez spécifier les types des variables locales à l'aide des balises [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Définitions].
 
 À partir de ce moment, l'IDE peut correctement vous faire des suggestions.
 

--- a/latte/hu/type-system.texy
+++ b/latte/hu/type-system.texy
@@ -21,7 +21,7 @@ Hogyan kezdjük el használni a típusokat? Hozzon létre egy sablonosztályt, p
 class CatalogTemplateParameters
 {
 	public function __construct(
-		public string $langs,
+		public string $lang,
 		/** @var ProductEntity[] */
 		public array $products,
 		public Address $address,
@@ -35,7 +35,7 @@ $latte->render('template.latte', new CatalogTemplateParameters(
 ));
 ```
 
-Ezután a sablon elejére illessze be a `{templateType}` taget az osztály teljes nevével (beleértve a névteret is). Ez definiálja, hogy a sablonban a `$langs` és `$products` változók a megfelelő típusokkal együtt léteznek. A lokális változók típusait a [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Definíciók define] tagekkel adhatja meg.
+Ezután a sablon elejére illessze be a `{templateType}` taget az osztály teljes nevével (beleértve a névteret is). Ez definiálja, hogy a sablonban a `$lang` és `$products` változók a megfelelő típusokkal együtt léteznek. A lokális változók típusait a [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Definíciók define] tagekkel adhatja meg.
 
 Ettől kezdve az IDE helyesen tud súgni.
 

--- a/latte/it/type-system.texy
+++ b/latte/it/type-system.texy
@@ -21,7 +21,7 @@ Come iniziare a usare i tipi? Create una classe di template, ad es. `CatalogTemp
 class CatalogTemplateParameters
 {
 	public function __construct(
-		public string $langs,
+		public string $lang,
 		/** @var ProductEntity[] */
 		public array $products,
 		public Address $address,
@@ -35,7 +35,7 @@ $latte->render('template.latte', new CatalogTemplateParameters(
 ));
 ```
 
-Quindi, all'inizio del template, inserite il tag `{templateType}` con il nome completo della classe (incluso il namespace). Questo definisce che nel template ci sono le variabili `$langs` e `$products` con i rispettivi tipi. Potete specificare i tipi delle variabili locali usando i tag [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Definizioni define].
+Quindi, all'inizio del template, inserite il tag `{templateType}` con il nome completo della classe (incluso il namespace). Questo definisce che nel template ci sono le variabili `$lang` e `$products` con i rispettivi tipi. Potete specificare i tipi delle variabili locali usando i tag [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Definizioni define].
 
 Da quel momento, l'IDE può suggerire correttamente.
 

--- a/latte/ja/type-system.texy
+++ b/latte/ja/type-system.texy
@@ -21,7 +21,7 @@
 class CatalogTemplateParameters
 {
 	public function __construct(
-		public string $langs,
+		public string $lang,
 		/** @var ProductEntity[] */
 		public array $products,
 		public Address $address,
@@ -35,7 +35,7 @@ $latte->render('template.latte', new CatalogTemplateParameters(
 ));
 ```
 
-次に、テンプレートの先頭に、クラスの完全な名前（名前空間を含む）を持つ `{templateType}` タグを挿入します。これにより、テンプレート内に変数 `$langs` と `$products` が、対応する型とともに定義されます。ローカル変数の型は、[`{var}` |tags#var default]、`{varType}`、[`{define}` |template-inheritance#Definitions] タグを使用して指定できます。
+次に、テンプレートの先頭に、クラスの完全な名前（名前空間を含む）を持つ `{templateType}` タグを挿入します。これにより、テンプレート内に変数 `$lang` と `$products` が、対応する型とともに定義されます。ローカル変数の型は、[`{var}` |tags#var default]、`{varType}`、[`{define}` |template-inheritance#Definitions] タグを使用して指定できます。
 
 その時点から、IDEは正しく補完できるようになります。
 

--- a/latte/pl/type-system.texy
+++ b/latte/pl/type-system.texy
@@ -21,7 +21,7 @@ Jak zacząć używać typów? Utwórz klasę szablonu, np. `CatalogTemplateParam
 class CatalogTemplateParameters
 {
 	public function __construct(
-		public string $langs,
+		public string $lang,
 		/** @var ProductEntity[] */
 		public array $products,
 		public Address $address,
@@ -35,7 +35,7 @@ $latte->render('template.latte', new CatalogTemplateParameters(
 ));
 ```
 
-A następnie na początku szablonu wstaw tag `{templateType}` z pełną nazwą klasy (włącznie z namespace). To definiuje, że w szablonie są zmienne `$langs` i `$products` wraz z odpowiednimi typami. Typy zmiennych lokalnych możesz podać za pomocą tagów [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Definicje define].
+A następnie na początku szablonu wstaw tag `{templateType}` z pełną nazwą klasy (włącznie z namespace). To definiuje, że w szablonie są zmienne `$lang` i `$products` wraz z odpowiednimi typami. Typy zmiennych lokalnych możesz podać za pomocą tagów [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Definicje define].
 
 Od tego momentu IDE może poprawnie podpowiadać.
 

--- a/latte/pt/type-system.texy
+++ b/latte/pt/type-system.texy
@@ -21,7 +21,7 @@ Como começar a usar tipos? Crie uma classe de template, por exemplo, `CatalogTe
 class CatalogTemplateParameters
 {
 	public function __construct(
-		public string $langs,
+		public string $lang,
 		/** @var ProductEntity[] */
 		public array $products,
 		public Address $address,
@@ -35,7 +35,7 @@ $latte->render('template.latte', new CatalogTemplateParameters(
 ));
 ```
 
-E, em seguida, no início do template, insira a tag `{templateType}` com o nome completo da classe (incluindo o namespace). Isso define que no template existem as variáveis `$langs` e `$products`, incluindo os tipos correspondentes. Você pode especificar os tipos de variáveis locais usando as tags [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Definições].
+E, em seguida, no início do template, insira a tag `{templateType}` com o nome completo da classe (incluindo o namespace). Isso define que no template existem as variáveis `$lang` e `$products`, incluindo os tipos correspondentes. Você pode especificar os tipos de variáveis locais usando as tags [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Definições].
 
 A partir desse momento, o IDE pode sugerir corretamente.
 

--- a/latte/ro/type-system.texy
+++ b/latte/ro/type-system.texy
@@ -21,7 +21,7 @@ Cum să începeți să utilizați tipurile? Creați o clasă de șablon, de exem
 class CatalogTemplateParameters
 {
 	public function __construct(
-		public string $langs,
+		public string $lang,
 		/** @var ProductEntity[] */
 		public array $products,
 		public Address $address,
@@ -35,7 +35,7 @@ $latte->render('template.latte', new CatalogTemplateParameters(
 ));
 ```
 
-Și apoi, la începutul șablonului, introduceți tag-ul `{templateType}` cu numele complet al clasei (inclusiv namespace). Acest lucru definește că în șablon există variabilele `$langs` și `$products` inclusiv tipurile corespunzătoare. Tipurile variabilelor locale pot fi specificate folosind tag-urile [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Definiții define].
+Și apoi, la începutul șablonului, introduceți tag-ul `{templateType}` cu numele complet al clasei (inclusiv namespace). Acest lucru definește că în șablon există variabilele `$lang` și `$products` inclusiv tipurile corespunzătoare. Tipurile variabilelor locale pot fi specificate folosind tag-urile [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Definiții define].
 
 Din acel moment, IDE-ul vă poate oferi sugestii corecte.
 

--- a/latte/ru/type-system.texy
+++ b/latte/ru/type-system.texy
@@ -21,7 +21,7 @@
 class CatalogTemplateParameters
 {
 	public function __construct(
-		public string $langs,
+		public string $lang,
 		/** @var ProductEntity[] */
 		public array $products,
 		public Address $address,
@@ -35,7 +35,7 @@ $latte->render('template.latte', new CatalogTemplateParameters(
 ));
 ```
 
-А затем в начало шаблона вставьте тег `{templateType}` с полным именем класса (включая пространство имен). Это определяет, что в шаблоне есть переменные `$langs` и `$products` с соответствующими типами. Типы локальных переменных можно указать с помощью тегов [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Определения].
+А затем в начало шаблона вставьте тег `{templateType}` с полным именем класса (включая пространство имен). Это определяет, что в шаблоне есть переменные `$lang` и `$products` с соответствующими типами. Типы локальных переменных можно указать с помощью тегов [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Определения].
 
 С этого момента IDE сможет правильно подсказывать.
 

--- a/latte/sl/type-system.texy
+++ b/latte/sl/type-system.texy
@@ -21,7 +21,7 @@ Kako začeti uporabljati tipe? Ustvarite si razred predloge, npr. `CatalogTempla
 class CatalogTemplateParameters
 {
 	public function __construct(
-		public string $langs,
+		public string $lang,
 		/** @var ProductEntity[] */
 		public array $products,
 		public Address $address,
@@ -35,7 +35,7 @@ $latte->render('template.latte', new CatalogTemplateParameters(
 ));
 ```
 
-Nato na začetek predloge vstavite značko `{templateType}` s polnim imenom razreda (vključno z imenskim prostorom). To definira, da so v predlogi spremenljivke `$langs` in `$products` vključno z ustreznimi tipi. Tipe lokalnih spremenljivk lahko navedete s pomočjo značk [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Definicije].
+Nato na začetek predloge vstavite značko `{templateType}` s polnim imenom razreda (vključno z imenskim prostorom). To definira, da so v predlogi spremenljivke `$lang` in `$products` vključno z ustreznimi tipi. Tipe lokalnih spremenljivk lahko navedete s pomočjo značk [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Definicije].
 
 Od takrat vam lahko IDE pravilno predlaga.
 

--- a/latte/tr/type-system.texy
+++ b/latte/tr/type-system.texy
@@ -21,7 +21,7 @@ Tipleri kullanmaya nasıl başlanır? İletilen parametreleri, tiplerini ve muht
 class CatalogTemplateParameters
 {
 	public function __construct(
-		public string $langs,
+		public string $lang,
 		/** @var ProductEntity[] */
 		public array $products,
 		public Address $address,
@@ -35,7 +35,7 @@ $latte->render('template.latte', new CatalogTemplateParameters(
 ));
 ```
 
-Ve ardından şablonun başına `{templateType}` etiketini sınıfın tam adıyla (ad alanı dahil) ekleyin. Bu, şablonda `$langs` ve `$products` değişkenlerinin ilgili tipleriyle birlikte bulunduğunu tanımlar. Yerel değişkenlerin tiplerini [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Tanımlar] etiketlerini kullanarak belirtebilirsiniz.
+Ve ardından şablonun başına `{templateType}` etiketini sınıfın tam adıyla (ad alanı dahil) ekleyin. Bu, şablonda `$lang` ve `$products` değişkenlerinin ilgili tipleriyle birlikte bulunduğunu tanımlar. Yerel değişkenlerin tiplerini [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Tanımlar] etiketlerini kullanarak belirtebilirsiniz.
 
 O andan itibaren IDE size doğru önerilerde bulunabilir.
 

--- a/latte/uk/type-system.texy
+++ b/latte/uk/type-system.texy
@@ -21,7 +21,7 @@
 class CatalogTemplateParameters
 {
 	public function __construct(
-		public string $langs,
+		public string $lang,
 		/** @var ProductEntity[] */
 		public array $products,
 		public Address $address,
@@ -35,7 +35,7 @@ $latte->render('template.latte', new CatalogTemplateParameters(
 ));
 ```
 
-А далі на початку шаблону вставте тег `{templateType}` з повною назвою класу (включаючи простір імен). Це визначає, що в шаблоні є змінні `$langs` та `$products` з відповідними типами. Типи локальних змінних можна вказати за допомогою тегів [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Визначення].
+А далі на початку шаблону вставте тег `{templateType}` з повною назвою класу (включаючи простір імен). Це визначає, що в шаблоні є змінні `$lang` та `$products` з відповідними типами. Типи локальних змінних можна вказати за допомогою тегів [`{var}` |tags#var default], `{varType}`, [`{define}` |template-inheritance#Визначення].
 
 З цього моменту ваше IDE може правильно підказувати.
 


### PR DESCRIPTION
The class instantiation uses singular both in the field name and in the method used for the value.

- bug fix   <!-- #issue numbers, if any -->
- BC break? no
- doc PR: nette/docs#1081  <!-- highly welcome, see https://nette.org/en/writing -->

<!--
Please use the latest released version (ie. last tagged commit) as a base for PR.

Describe your changes here to communicate to the maintainers why we should accept this pull request.

Please add new tests to show the fix or feature works. And take a moment to read the contributing guide https://nette.org/en/contributing

Thanks for contributing to Nette!
-->
