### PR TITLE
Update troubleshooting.texy

### DIFF
--- a/nette/cs/troubleshooting.texy
+++ b/nette/cs/troubleshooting.texy
@@ -121,21 +121,52 @@ location / {
 
 Block `location` se pro každou filesystémovou cestu smí v bloku `server` vyskytovat jen jednou. Pokud již v konfiguraci `location /` máte, přidejte direktivu `try_files` do něj.
 
-**IIS**: je potřeba povolit a nastavit URL Rewrite modul. Vytvořte soubor web.config v adresáři public/ (tedy vedle souboru index.php):
+**IIS**: je potřeba povolit a nastavit URL Rewrite modul. Vytvořte soubor `web.config` v adresáři `public/` (tedy vedle souboru `index.php`):
 
 ```iis
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <system.webServer>
-        <directoryBrowse enabled="false" />
+        <defaultDocument>
+            <files>
+                <clear />
+                <add value="index.php" />
+                <add value="Default.htm" />
+                <add value="Default.asp" />
+                <add value="index.htm" />
+                <add value="index.html" />
+                <add value="iisstart.htm" />
+            </files>
+        </defaultDocument>
         <rewrite>
             <rules>
+                <rule name="HTTPS Redirect" stopProcessing="true">
+                    <match url=".?" ignoreCase="false" />
+                    <conditions logicalGrouping="MatchAll">
+                        <add input="{HTTPS}" pattern="on" ignoreCase="false" negate="true" />
+                    </conditions>
+                    <action type="Redirect" url="https://{HTTP_HOST}{URL}" redirectType="Permanent" />
+                </rule>
+                <rule name="Well-known" stopProcessing="true">
+                    <match url="^\.well-known/.*" ignoreCase="false" />
+                    <action type="None" />
+                </rule>
+                <rule name="Security" stopProcessing="true">
+                    <match url="/\.|^\.|^wp-(login|admin|includes|content)" ignoreCase="false" />
+                    <action type="CustomResponse" statusCode="403" statusReason="Forbidden" statusDescription="Forbidden" />
+                </rule>
+                <rule name="Static files" stopProcessing="true">
+                    <match url="\.(pdf|js|mjs|ico|gif|jpg|jpeg|png|webp|avif|svg|css|rar|zip|7z|tar\.gz|map|eot|ttf|otf|woff|woff2)$" ignoreCase="false" />
+                    <conditions logicalGrouping="MatchAll">
+                        <add input="{REQUEST_FILENAME}" matchType="IsFile" ignoreCase="false" negate="true" />
+                    </conditions>
+                    <action type="None" />
+                </rule>
                 <rule name="RewriteToIndex" stopProcessing="true">
-                    <match url="^(.*)$" />
-                    <conditions>
-                        <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
-                        <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
-                        <add input="{REQUEST_URI}" pattern="\.(css|js|ico|zip|rar|png|jpg|gif|pdf|tar\.gz)$" negate="true" />
+                    <match url="." ignoreCase="false" />
+                    <conditions logicalGrouping="MatchAll">
+                        <add input="{REQUEST_FILENAME}" matchType="IsFile" ignoreCase="false" negate="true" />
+                        <add input="{REQUEST_FILENAME}" matchType="IsDirectory" ignoreCase="false" negate="true" />
                     </conditions>
                     <action type="Rewrite" url="index.php" />
                 </rule>
@@ -147,42 +178,11 @@ Block `location` se pro každou filesystémovou cestu smí v bloku `server` vysk
 
 Pokud narazíte na problémy, ujistěte se, že:
 
-- soubor web.config se nachází v adresáři public/ (tedy vedle souboru index.php)
+- soubor `web.config` se nachází v adresáři `www/` (tedy vedle souboru `index.php`)
 - je nainstalován modul URL Rewrite pro IIS (lze stáhnout z webu Microsoft nebo přes Web Platform Installer)
 - aplikační pool má nastaven Managed Pipeline Mode na Integrated
 - PHP je nakonfigurováno jako FastCGI handler v IIS
 
-Pokud nastavujete aplikaci v podsložce (např. https://example.com/moje-aplikace/), vytvořte navíc soubor web.config v kořenovém adresáři webu:
-
-```iis
-<?xml version="1.0" encoding="UTF-8"?>
-<configuration>
-    <system.webServer>
-        <rewrite>
-            <rules>
-                <rule name="RedirectToPublic" stopProcessing="true">
-                    <match url="^$" />
-                    <action type="Redirect" url="public/" />
-                </rule>
-                <rule name="RewriteToPublic" stopProcessing="true">
-                    <match url="^(.*)$" />
-                    <conditions>
-                        <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
-                        <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
-                        <add input="{REQUEST_URI}" pattern="^public/" negate="true" />
-                    </conditions>
-                    <action type="Rewrite" url="public/{R:1}" />
-                </rule>
-            </rules>
-        </rewrite>
-        <httpErrors errorMode="DetailedLocalOnly" />
-    </system.webServer>
-    <system.web>
-        <customErrors mode="Off" />
-        <compilation debug="false" />
-    </system.web>
-</configuration>
-```
 
 Ověření, že funguje `.htaccess`
 -------------------------------

--- a/nette/cs/troubleshooting.texy
+++ b/nette/cs/troubleshooting.texy
@@ -121,6 +121,68 @@ location / {
 
 Block `location` se pro každou filesystémovou cestu smí v bloku `server` vyskytovat jen jednou. Pokud již v konfiguraci `location /` máte, přidejte direktivu `try_files` do něj.
 
+**IIS**: je potřeba povolit a nastavit URL Rewrite modul. Vytvořte soubor web.config v adresáři public/ (tedy vedle souboru index.php):
+
+```iis
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <system.webServer>
+        <directoryBrowse enabled="false" />
+        <rewrite>
+            <rules>
+                <rule name="RewriteToIndex" stopProcessing="true">
+                    <match url="^(.*)$" />
+                    <conditions>
+                        <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
+                        <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
+                        <add input="{REQUEST_URI}" pattern="\.(css|js|ico|zip|rar|png|jpg|gif|pdf|tar\.gz)$" negate="true" />
+                    </conditions>
+                    <action type="Rewrite" url="index.php" />
+                </rule>
+            </rules>
+        </rewrite>
+    </system.webServer>
+</configuration>
+```
+
+Pokud narazíte na problémy, ujistěte se, že:
+
+- soubor web.config se nachází v adresáři public/ (tedy vedle souboru index.php)
+- je nainstalován modul URL Rewrite pro IIS (lze stáhnout z webu Microsoft nebo přes Web Platform Installer)
+- aplikační pool má nastaven Managed Pipeline Mode na Integrated
+- PHP je nakonfigurováno jako FastCGI handler v IIS
+
+Pokud nastavujete aplikaci v podsložce (např. https://example.com/moje-aplikace/), vytvořte navíc soubor web.config v kořenovém adresáři webu:
+
+```iis
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <system.webServer>
+        <rewrite>
+            <rules>
+                <rule name="RedirectToPublic" stopProcessing="true">
+                    <match url="^$" />
+                    <action type="Redirect" url="public/" />
+                </rule>
+                <rule name="RewriteToPublic" stopProcessing="true">
+                    <match url="^(.*)$" />
+                    <conditions>
+                        <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
+                        <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
+                        <add input="{REQUEST_URI}" pattern="^public/" negate="true" />
+                    </conditions>
+                    <action type="Rewrite" url="public/{R:1}" />
+                </rule>
+            </rules>
+        </rewrite>
+        <httpErrors errorMode="DetailedLocalOnly" />
+    </system.webServer>
+    <system.web>
+        <customErrors mode="Off" />
+        <compilation debug="false" />
+    </system.web>
+</configuration>
+```
 
 Ověření, že funguje `.htaccess`
 -------------------------------


### PR DESCRIPTION
Doplněna nápověda, jak nastavit server pro hezká URL pro IIS

- new feature
- BC break: no
- doc PR: nette/docs#??? (pokud jsi změnil i dokumentaci, jinak odstraň)

## Popis změny
Přidána konfigurace pro IIS webserver (web.config) jako ekvivalent 
stávající Apache (.htaccess) konfigurace pro URL rewriting.

## Co bylo přidáno
- Konfigurace web.config pro složku public/ (RewriteToIndex pravidlo)
- Konfigurace web.config pro kořenový adresář při běhu v podsložce
- Seznam požadavků pro správnou funkci (URL Rewrite modul, FastCGI, atd.)

## Testováno na
- IIS 10 / Windows Server 2019
- PHP 8.5 jako FastCGI